### PR TITLE
Fix 11ty passthrough copy error

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,9 +7792,9 @@ rechoir@^0.7.0:
     resolve "^1.9.0"
 
 recursive-copy@^2.0.11:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.12.tgz#8e1094116b4e6131e09cef103ae2c03e0cce7c90"
-  integrity sha512-gvXvP6Dp++LPgHvwjnOo4qU9vbjkAVOvwOkvNZORH9vuNmDSLtnLdmRNPYhC3EwDYdSO5Dd3O7ZQWH5KsnC+NA==
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.13.tgz#ace471459650f379d4127dd64aa2a4ceca808aa2"
+  integrity sha512-BjmE6R/dOImStEku+017L3Z0I6u/lA+SVr1sySWbTLjmQKDTESNmJ9WBZP8wbN5FuvqNvSYvRKA/IKQhAjqnpQ==
   dependencies:
     del "^2.2.0"
     errno "^0.1.2"


### PR DESCRIPTION
Hi there - I'm the author of `recursive-copy`, one of the dependencies of 11ty.

I noticed you recently filed a bug report on the 11ty repo that referenced some `Cannot read property 'sort' of undefined` error messages - this was a bug in `recursive-copy@2.0.12` which was released a few hours ago; this bug is fixed in the latest `recursive-copy@2.0.13` so if you merge this PR that should fix those errors.

I think the other errors you were seeing (`document is not defined`) are unrelated - the stack trace seems to imply this is something to do with Prism markdown component.

Apologies for this!