### PR TITLE
Rework code blocks to use markdown-it-attrs

### DIFF
--- a/config/plugins/markdown.js
+++ b/config/plugins/markdown.js
@@ -1,5 +1,6 @@
 const markdownIt = require('markdown-it');
 const markdownItPrism = require('markdown-it-prism');
+const markdownItAttrs = require('markdown-it-attrs');
 const markdownItAnchor = require('markdown-it-anchor');
 const markdownItKatex = require('@iktakahiro/markdown-it-katex');
 const markdownItClass = require('@toycode/markdown-it-class');
@@ -15,6 +16,7 @@ const markdownLib = markdownIt({
   .use(markdownItPrism, {
     defaultLanguage: 'plaintext',
   })
+  .use(markdownItAttrs)
   .use(markdownItAnchor, {
     slugify: slugifyString,
     tabIndex: false,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lodash": "^4.17.21",
     "markdown-it": "^12.0.6",
     "markdown-it-anchor": "^8.0.3",
+    "markdown-it-attrs": "^4.1.3",
     "markdown-it-link-attributes": "^3.0.0",
     "markdown-it-prism": "^2.2.2",
     "markdown-it-toc-done-right": "^4.2.0",

--- a/src/_includes/codeHeader.html
+++ b/src/_includes/codeHeader.html
@@ -1,9 +1,0 @@
-{%- assign filename = file -%}
-<div class="code-header{% unless copyable == false %} with-copy-button{% endunless %}{% if filename %} with-file-name{% endif %}">
-  {%- if filename -%}
-    <div class="code-file-name">{{ filename }}</div>
-  {%- endif -%}
-  {%- unless copyable == false -%}
-    <button class="copy-code-button font-sm" aria-label="Copy code to clipboard" type="button"></button>
-  {%- endunless -%}
-</div>

--- a/src/_posts/2019-08-18-trie-data-structure-implementation-in-python.md
+++ b/src/_posts/2019-08-18-trie-data-structure-implementation-in-python.md
@@ -67,8 +67,7 @@ First, like all trees, a prefix tree is going to consist of nodes. Each node wil
 
 Let's build the `TrieNode` class:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 class TrieNode:
     def __init__(self, text = ''):
         self.text = text
@@ -79,8 +78,7 @@ Pretty simple, right? Again, note that there's one additional piece of data we'l
 
 Next, the prefix tree itself consists of one or more of these `TrieNodes`, so I'll add another class named `PrefixTree`:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 class TrieNode:
     def __init__(self, text = ''):
         self.text = text
@@ -122,8 +120,7 @@ Recall that each node also has to keep track of the string that's been generated
 
 Here's the full* Python implementation of inserting nodes into a trie:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def insert(self, word):
     current = self.root
     for i, char in enumerate(word):
@@ -149,8 +146,7 @@ Otherwise, if we reach the last character of the string without having returned 
 
 Here's the code:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def find(self, word):
     '''
     Returns the TrieNode representing the given word if it exists
@@ -184,8 +180,7 @@ Fortunately, the fix here is super simple. We need to make three changes:
 
 Let's modify the `TrieNode` class:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 class TrieNode:
     def __init__(self, text = ''):
         self.text = text
@@ -195,8 +190,7 @@ class TrieNode:
 
 And then the `insert` method:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def insert(self, word):
     current = self.root
     for i, char in enumerate(word):
@@ -211,8 +205,7 @@ And finally, to verify that the given word exists in our trie, and that the node
 
 Here's the final code for `find`:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def find(self, word):
     '''
     Returns the TrieNode representing the given word if it exists
@@ -248,8 +241,7 @@ The code for finding partial matches in a trie is also really simple. Here's the
 
 The first step is simple—we just did something very similar above for finding exact matches. This time, though, instead of returning `None` when a match isn't found, we'll return an empty list.
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def starts_with(self, prefix):
     '''
     Returns a list of all words beginning with the given prefix, or
@@ -270,8 +262,7 @@ Once we've found the prefix node (if it exists), we'll utilize a helper method f
 
 Here's the recursive helper function:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def __child_words_for(self, node, words):
     '''
     Private helper function. Cycles through all children
@@ -286,8 +277,7 @@ def __child_words_for(self, node, words):
 
 And here's the completed code for `starts_with`:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def starts_with(self, prefix):
     '''
     Returns a list of all words beginning with the given prefix, or
@@ -318,8 +308,7 @@ This one depends on your definition of "size." Is it the number of *words* that 
 
 I'll just show the code this time—hopefully you're comfortable with recursion and tries by now:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 def size(self, current = None):
     '''
     Returns the size of this prefix tree, defined
@@ -340,8 +329,7 @@ Notice that `current` has a default value of `None`. This allows the user to sim
 
 We can add this to the end of our script to manually test our code:
 
-{% include codeHeader.html file: "trie.py" %}
-```python
+```python {data-file="trie.py" data-copyable=true}
 if __name__ == '__main__':
     trie = PrefixTree()
     trie.insert('apple')
@@ -359,8 +347,7 @@ But this is tedious and frankly not a very rigorous way of testing our code. So 
 
 Below are eight tests covering edge cases. This is where our `size` method really comes in handy.
 
-{% include codeHeader.html file: "test_trie.py" %}
-```python
+```python {data-file="test_trie.py" data-copyable=true}
 import unittest
 from trie import PrefixTree
 

--- a/src/_posts/2019-12-11-heading-links-in-jekyll.md
+++ b/src/_posts/2019-12-11-heading-links-in-jekyll.md
@@ -28,9 +28,8 @@ Then, we want two states:
 
 With Liquid and Jekyll includes, it's super simple to create linked headings. Here's the markup:
 
-{% include codeHeader.html file: "_includes/linkedHeading.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="_includes/linkedHeading.html" data-copyable=true}
 {% assign heading = include.heading %}
 <h{{ include.level }} id="{{ heading | slugify }}" class="linked-heading">
     <span class="heading-anchor-wrapper">
@@ -49,8 +48,7 @@ With Liquid and Jekyll includes, it's super simple to create linked headings. He
 
 And here's the Sass:
 
-{% include codeHeader.html %}
-```sass
+```sass {data-copyable=true}
 .linked-heading {
     position: relative;
 
@@ -92,9 +90,8 @@ And here's the Sass:
 
 Simply use the following in your markdown to create a heading anchor in Jekyll:
 
-{% include codeHeader.html %}
 {% raw %}
-```liquid
+```liquid {data-copyable=true}
 {% include linkedHeading.html heading="My Heading" level=someNumber %}
 ```
 {% endraw %}
@@ -120,8 +117,7 @@ If you have a sticky/fixed navbar like I do on this site, you may run into a pro
 
 Fortunately, the fix is simple: we can add a `scroll-margin-top` to our headings equal to the height of the navbar plus a certain offset, like so:
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 h1, h2, h3, h4, h5, h6 {
     /* 64px navbar + 20px for spacing */
     scroll-margin-top: 84px;
@@ -145,9 +141,8 @@ There are two solutions to this:
 
 Here's the one I use:
 
-{% include codeHeader.html file: "markdown.json" %}
 {% raw %}
-```json
+```json {data-file="markdown.json" data-copyable=true}
 "Linked Heading": {
     "prefix": "heading",
     "body": [

--- a/src/_posts/2019-12-28-least-squares-fitting.md
+++ b/src/_posts/2019-12-28-least-squares-fitting.md
@@ -458,8 +458,7 @@ Straight-line fitting is pretty simple by hand, but polynomial least squares fit
 
 Here's a script that uses QR factorization explicitly:
 
-{% include codeHeader.html file: "lsq.py" %}
-```python
+```python {data-file="lsq.py" data-copyable=true}
 import numpy as np
 from numpy import linalg as LA
 
@@ -481,8 +480,7 @@ print(theta)
 
 However, this is really equivalent to the following code, which just uses the `LA.lstsq` function:
 
-{% include codeHeader.html file: "lsq.py" %}
-```python
+```python {data-file="lsq.py" data-copyable=true}
 import numpy as np
 from numpy import linalg as LA
 

--- a/src/_posts/2020-01-05-improve-page-load-speed-in-jekyll-using-the-webp-image-format.md
+++ b/src/_posts/2020-01-05-improve-page-load-speed-in-jekyll-using-the-webp-image-format.md
@@ -68,8 +68,7 @@ The good news is that [browser support for WebP](https://caniuse.com/#feat=webp)
 
 Assuming you want to cover all your bases and ensure that your images are displaying properly, you can use a `picture` element with a `source` for the WebP version and a backup `img` for the regular format:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <picture>
   <source srcset="/path/to/image.webp" type="image/webp">
   <img src="/path/to/image.jpg" alt="Your alt text" />
@@ -84,9 +83,8 @@ Except... Do we really have to copy-paste this every time we want to create an i
 
 Time to make this reusable! Create a file named `_includes/picture.html` and add this markup:
 
-{% include codeHeader.html file: "_includes/picture.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="_includes/picture.html" data-copyable=true}
 {% assign img = include.img %}
 <picture>
     <source type="image/webp" srcset="/assets/images/posts/{{ page.slug }}/{{ img }}.webp" >
@@ -114,9 +112,8 @@ Here's a screenshot to make that clearer:
 
 That allows us to get away with this simple and legible include:
 
-{% include codeHeader.html %}
 {% raw %}
-```liquid
+```liquid {data-copyable=true}
 {% include picture.html img="my-image.jpg" alt="My alt text" %}
 ```
 {% endraw %}

--- a/src/_posts/2020-01-09-invulnerability-frames-in-unity.md
+++ b/src/_posts/2020-01-09-invulnerability-frames-in-unity.md
@@ -38,8 +38,7 @@ Instead, we want to use [coroutines](https://docs.unity3d.com/Manual/Coroutines.
 
 We'll start by adding this method somewhere in our Player script:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     // logic goes here
@@ -50,15 +49,13 @@ Notice that this method returns an `IEnumerator`; all coroutines in Unity do tha
 
 We'll use a private member variable to keep track of whether the player is invincible:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private bool isInvincible = false;
 ```
 
 When the player becomes invincible, we flip this flag to true:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     Debug.Log("Player turned invincible!");
@@ -90,8 +87,7 @@ void MethodThatTriggersInvulnerability()
 
 For example, if players become invulnerable in your game when taking damage, you might do something like this:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 public void LoseHealth(int amount)
 {
     if (isInvincible) return;
@@ -118,8 +114,7 @@ If you want to initiate the invulnerability frames some other way, like when the
 
 Our coroutine looks like this so far:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     Debug.Log("Player turned invincible!");
@@ -131,8 +126,7 @@ Hmm... We don't want our player to be invulnerable to damage forever—that woul
 
 First, declare this private member variable at the top of your script:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 [SerializeField]
 private float invincibilityDurationSeconds;
 ```
@@ -145,8 +139,7 @@ Before we use this variable, we must initialize it via the inspector pane or in 
 
 Then, we can simply use it like so:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     Debug.Log("Player turned invincible!");
@@ -173,8 +166,7 @@ To create discrete invulnerability frames, we're going to have to modify our cor
 
 Before we do that, let's add a second member variable at the top of our script:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 [SerializeField]
 private float invincibilityDeltaTime;
 ```
@@ -183,8 +175,7 @@ Again, go ahead and initialize this new variable via the Unity inspector or in `
 
 Now, let's rewrite our coroutine to use a loop instead of just yielding once:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     Debug.Log("Player turned invincible!");
@@ -221,8 +212,7 @@ Making a player flash while they're invulnerable is a classic approach in old/re
 
 The easiest way to make a player flash in Unity is to repeatedly scale their model (or sprite, for 2D) between `0` and `1`. First, we need to actually get ahold of the player model:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 [SerializeField]
 private GameObject model;
 ```
@@ -237,8 +227,7 @@ In your editor, drag and drop the model object into the appropriate slot in the 
 
 Next, we'll add a method that lets us easily scale this model:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private void ScaleModelTo(Vector3 scale)
 {
     model.transform.localScale = scale;
@@ -247,8 +236,7 @@ private void ScaleModelTo(Vector3 scale)
 
 And finally, we'll actually do the model scaling in our coroutine:
 
-{% include codeHeader.html file: "Player.cs" %}
-```csharp
+```csharp {data-file="Player.cs" data-copyable=true}
 private IEnumerator BecomeTemporarilyInvincible()
 {
     Debug.Log("Player turned invincible!");

--- a/src/_posts/2020-02-08-finite-state-machine-fsm-tutorial-implementing-an-fsm-in-c.md
+++ b/src/_posts/2020-02-08-finite-state-machine-fsm-tutorial-implementing-an-fsm-in-c.md
@@ -26,8 +26,7 @@ Suppose we have a lightbulb that can have the following states:
 
 We can model this using an enum:
 
-{% include codeHeader.html file: "LightState.h" %}
-```cpp
+```cpp {data-file="LightState.h" data-copyable=true}
 #pragma once
 
 enum class LightState {
@@ -52,8 +51,7 @@ Usually, whenever you can model a scenario with finite state machines, you can a
 
 So, we'll model our light's state transitions with an actual map data structure, where the key is the current state and the value is the next state:
 
-{% include codeHeader.html file: "LightState.h" %}
-```cpp
+```cpp {data-file="LightState.h" data-copyable=true}
 #pragma once
 #include <map>
 
@@ -74,8 +72,7 @@ std::map<LightState, LightState> lightTransitions = {
 
 Let's also create our simple `Light` class:
 
-{% include codeHeader.html file: "Light.h" %}
-```cpp
+```cpp {data-file="Light.h" data-copyable=true}
 #pragma once
 #include "LightState.h"
 
@@ -91,8 +88,7 @@ private:
 };
 ```
 
-{% include codeHeader.html file: "Light.cpp" %}
-```cpp
+```cpp {data-file="Light.cpp" data-copyable=true}
 #include "Light.h"
 
 Light::Light()
@@ -118,8 +114,7 @@ For example, maybe we want to toggle the intensity of the lightbulb with each st
 
 We could certainly do this—just add some code before and after the line where we're changing the state:
 
-{% include codeHeader.html file: "Light.cpp" %}
-```cpp
+```cpp {data-file="Light.cpp" data-copyable=true}
 void Light::toggle()
 {
 	// ... do something here before the transition
@@ -138,8 +133,7 @@ Now that we've looked at how to create a state transition table, we can implemen
 
 Instead of using a state transition table and a `LightState` *enum*, what if we make each concrete light state its own *class*? That way, we can delegate the task of determining the next state to the *current state* that a light is in. In other words, I'm proposing that we do something like this, where invoking a light's `toggle` method in turn invokes the current state's `toggle` method (because remember—we're now going to use classes instead of enums for the states):
 
-{% include codeHeader.html file: "Light.h", copyable: false %}
-```cpp
+```cpp {data-file="Light.h"}
 #pragma once
 #include "LightState.h"
 
@@ -160,8 +154,7 @@ private:
 };
 ```
 
-{% include codeHeader.html file: "Light.cpp", copyable: false %}
-```cpp
+```cpp {data-file="Light.cpp"}
 #include "Light.h"
 
 // TODO: set the initial state here
@@ -230,8 +223,7 @@ To understand how this all works in practice, we'll implement everything from sc
 
 Let's first define the abstract `LightState` class. You'll notice some forward declarations that are necessary to resolve circular includes that would otherwise throw off the C++ linker.
 
-{% include codeHeader.html file: "LightState.h" %}
-```cpp
+```cpp {data-file="LightState.h" data-copyable=true}
 #pragma once
 #include "Light.h"
 
@@ -261,8 +253,7 @@ Next, we'll declare all of our concrete state classes. We'll force each one to b
 1. Defining a static `getInstance` method that returns a pointer to the singleton.
 2. Declaring all constructors, copy constructors, and assignment operators as private.
 
-{% include codeHeader.html file: "ConcreteLightStates.h" %}
-```cpp
+```cpp {data-file="ConcreteLightStates.h" data-copyable=true}
 #pragma once
 #include "LightState.h"
 #include "Light.h"
@@ -328,8 +319,7 @@ I created inlined, empty definitions for the `enter` and `exit` methods, as thes
 
 Let's also create definitions for all of the `toggle` and `getInstance` methods, to make things clearer:
 
-{% include codeHeader.html file: "ConcreteLightStates.cpp" %}
-```cpp
+```cpp {data-file="ConcreteLightStates.cpp" data-copyable=true}
 #include "ConcreteLightStates.h"
 
 void LightOff::toggle(Light* light)
@@ -389,8 +379,7 @@ Notice how each `toggle` method initiates the appropriate state transition by in
 
 The final piece of the puzzle is the `Light` class, particularly the `setState` method:
 
-{% include codeHeader.html file: "Light.h" %}
-```cpp
+```cpp {data-file="Light.h" data-copyable=true}
 #pragma once
 #include "LightState.h"
 
@@ -411,8 +400,7 @@ private:
 };
 ```
 
-{% include codeHeader.html file: "Light.cpp" %}
-```cpp
+```cpp {data-file="Light.cpp" data-copyable=true}
 #include "Light.h"
 #include "ConcreteLightStates.h"
 

--- a/src/_posts/2020-02-19-getting-started-with-jekyll-and-github-pages.md
+++ b/src/_posts/2020-02-19-getting-started-with-jekyll-and-github-pages.md
@@ -68,15 +68,13 @@ Assuming that everything went well, it's time to make your first Jekyll site.
 
 Running this command will set up a folder named `mysite` with all of the necessary starter files and directories:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 bundle exec jekyll new mysite
 ```
 
 If you already have existing source files in a project directory for your site, you can instead run this:
 
-{% include codeHeader.html file: "Gemfile", copyable: false %}
-```bash
+```bash {data-file="Gemfile"}
 cd mysite
 bundle exec jekyll new . --force
 ```
@@ -93,8 +91,7 @@ The end result should be this simple directory structure:
 
 Go ahead and open up the Gemfile at the root of your project. You'll find useful comments in there to help you configure Jekyll with GitHub Pages:
 
-{% include codeHeader.html file: "_Gemfile" %}
-```ruby
+```ruby {data-file="_Gemfile" data-copyable=true}
 source "https://rubygems.org"
 
 # Hello! This is where you manage which Jekyll version is used to run.
@@ -165,8 +162,7 @@ If you don't use `theme: null`, the `github-pages` gem will automatically genera
 
 After doing all of that, run this command to install and update all necessary gems for your site:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 bundle install
 ```
 
@@ -183,8 +179,7 @@ You should also now see a `Gemfile.lock` file at the root of your project. This 
 
 Let's fire her up and see what we've got:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 bundle exec jekyll serve --livereload
 ```
 
@@ -192,15 +187,13 @@ By default, this runs your site on `localhost:4000` with live-reloading enabled,
 
 You can change the port in one of two ways. The first is to specify the `--port` argument:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 bundle exec jekyll serve --livereload --port 4001
 ```
 
 The second is to add this line somewhere inside your project's `_config.yml` file:
 
-{% include codeHeader.html %}
-```yml
+```yml {data-copyable=true}
 port: 4001
 ```
 
@@ -222,8 +215,7 @@ The remainder of this tutorial assumes that your theme is set to `null`. Some of
 
 If you haven't already done so, push your Jekyll site to GitHub Pages:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git add . && git push
 ```
 
@@ -252,8 +244,7 @@ If none of this makes sense to you right now, or if all of this seems overwhelmi
 
 We already saw that you can edit your Jekyll starter theme in `_config.yml`, but that's not all that this file allows you to do. In fact, this file houses your entire site's configuration settings. Here's what mine looks like so far:
 
-{% include codeHeader.html file: "_config.yml", copyable: false %}
-```yml
+```yml {data-file="_config.yml"}
 # Welcome to Jekyll!
 #
 # This config file is meant for settings that affect your whole blog, values
@@ -315,8 +306,7 @@ If you have any experience working with plain old HTML to create sites, you shou
 
 In your project directory, you should see a mostly empty file named `index.md` that looks something like this:
 
-{% include codeHeader.html file: "index.md", copyable: false %}
-```markdown
+```markdown {data-file="index.md"}
 ---
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
@@ -340,8 +330,7 @@ Kramdown extends Markdown with some useful features, like adding classes and IDs
 
 Before moving on, let's modify `index.md` as follows:
 
-{% include codeHeader.html file: "index.md" %}
-```markdown
+```markdown {data-file="index.md" data-copyable=true}
 ---
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
@@ -358,8 +347,7 @@ If live-reloading is enabled, you should see your page update automatically to d
 
 As I noted earlier, you can optionally also use plain HTML to get the same result:
 
-{% include codeHeader.html file: "index.md" %}
-```markdown
+```markdown {data-file="index.md" data-copyable=true}
 ---
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
@@ -372,8 +360,7 @@ layout: home
 
 Notice that we have to specify the ID explicitly with HTML, whereas Markdown does it automatically for us. If you wanted to, you could achieve the same result using Kramdown's ID specifier:
 
-{% include codeHeader.html file: "index.md" %}
-```markdown
+```markdown {data-file="index.md" data-copyable=true}
 ---
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
@@ -386,8 +373,7 @@ layout: home
 
 To understand more about what goes on behind the scenes in Jekyll, go ahead and expand your Git-ignored `_site` directory. Remember that this is the build directory that Jekyll creates each time you change a file, while `jekyll serve` is running. You should see that there's an `index.html` in there. Open that up to see its contents:
 
-{% include codeHeader.html file: "_site/index.html" %}
-```html
+```html {data-file="_site/index.html" data-copyable=true}
 <h1 id="hello-jekyll">Hello, Jekyll!</h1>
 ```
 
@@ -442,9 +428,8 @@ Since these are not among the predefined front matter variables that Jekyll reco
 
 While we're on the topic of front matter, go ahead and open up the starter blog post that Jekyll created for us. On my end, it's located under `_posts/2020-02-14-welcome-to-jekyll.markdown` and has this content:
 
-{% include codeHeader.html file: "_posts/2020-02-14-welcome-to-jekyll.markdown" %}
 {% raw %}
-```markdown
+```markdown {data-file="_posts/2020-02-14-welcome-to-jekyll.markdown" data-copyable=true}
 ---
 layout: post
 title:  "Welcome to Jekyll!"
@@ -494,8 +479,7 @@ The starter post that we saw earlier has a layout of `post`. Surely all of our o
 
 Nope! Open up your `_config.yml`, and add this YAML somewhere (anywhere):
 
-{% include codeHeader.html %}
-```yml
+```yml {data-copyable=true}
 defaults:
   -
     scope:
@@ -517,8 +501,7 @@ And then restart your server.
 
 Jekyll allows you to define **front matter defaults** like we've done here by scope, which you can narrow down using either a path or file type. The above defaults are equivalent to doing this manually in each post that we create under `_posts/`:
 
-{% include codeHeader.html file: "_posts/2020-02-14-an-awesome-post.md", copyable: false %}
-```markdown
+```markdown {data-file="_posts/2020-02-14-an-awesome-post.md"}
 ---
 is_post: true
 layout: post
@@ -527,8 +510,7 @@ layout: post
 
 And doing this manually for each page—like our home page, experience page, contact page, and so on—that we create under a directory named `_pages/`:
 
-{% include codeHeader.html file: "_pages/contact.md", copyable: false %}
-```markdown
+```markdown {data-file="_pages/contact.md"}
 ---
 is_post: false
 layout: default
@@ -549,8 +531,7 @@ The Jekyll starter already comes with two such files at the root of the project:
 
 First, create this directory, either via a UI or Bash:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 mkdir _pages
 ```
 
@@ -572,8 +553,7 @@ It's not Jekyll's fault that our two pages disappeared—we didn't tell it where
 
 Open up your `_config.yml` and add this line somewhere:
 
-{% include codeHeader.html %}
-```yml
+```yml {data-copyable=true}
 include: [_pages]
 ```
 
@@ -591,8 +571,7 @@ Okay, it looks like that added `_pages/` to our build directory, and we can now 
 
 The final step is to [specify permalinks to our pages](https://jekyllrb.com/docs/permalinks/) using a predefined front matter variable named `permalink`:
 
-{% include codeHeader.html file: "_pages/index.md" %}
-```markdown
+```markdown {data-file="_pages/index.md" data-copyable=true}
 ---
 permalink: /
 ---
@@ -602,8 +581,7 @@ permalink: /
 
 If you open up `about.md`, you'll notice that it already had a relative permalink defined in its front matter block:
 
-{% include codeHeader.html file: "_pages/about.md", copyable: false %}
-```markdown
+```markdown {data-file="_pages/about.md"}
 ---
 layout: page
 title: About
@@ -630,8 +608,7 @@ Save your changes, and Jekyll will rebuild the `_site/` directory. If you refres
 
 If you want to navigate to the About page, simply add `/about/` to the end of `localhost:4000` in your browser's navigation bar. Or you can use navigation links on your page:
 
-{% include codeHeader.html file: "_pages/index.md" %}
-```markdown
+```markdown {data-file="_pages/index.md" data-copyable=true}
 ---
 permalink: /
 ---
@@ -674,8 +651,7 @@ I want to take a second to demystify some things about blog posts in Jekyll. Mos
 
 We can give each blog post a permalink, too, just like we did with our pages above. But again, we don't want to have to repeat this every single time we create a post. Let's add a permalink to the defaults in our `_config.yml`:
 
-{% include codeHeader.html %}
-```yml
+```yml {data-copyable=true}
 defaults:
   -
     scope:
@@ -702,8 +678,7 @@ permalink: /blog/:categories/:title/
 
 Recall that the starter blog post defines two categories, `jekyll` and `update`, plus the title `Welcome to Jekyll!`:
 
-{% include codeHeader.html file: "_posts/2020-02-14-welcome-to-jekyll.markdown" %}
-```markdown
+```markdown {data-file="_posts/2020-02-14-welcome-to-jekyll.markdown" data-copyable=true}
 ---
 layout: post
 title:  "Welcome to Jekyll!"
@@ -788,9 +763,8 @@ So the `date` front matter variable is in fact redundant because we already have
 
 To verify this, let's try an experiment. Remove the date from the post's front matter, and replace the file with this:
 
-{% include codeHeader.html file: "_posts/2020-02-14-welcome-to-jekyll.markdown" %}
 {% raw %}
-```markdown
+```markdown {data-file="_posts/2020-02-14-welcome-to-jekyll.markdown" data-copyable=true}
 ---
 title:  "Welcome to Jekyll!"
 layout: post
@@ -1055,8 +1029,7 @@ Layout files in Jekyll are housed under the `_layouts/` directory. Recall that t
 
 It's easier to understand this with an example. If we go back to `_pages/about.md`, we'll find a layout declared in its front matter block:
 
-{% include codeHeader.html file: "_pages/about.md", copyable: false %}
-```markdown
+```markdown {data-file="_pages/about.md"}
 ---
 layout: page
 title: About
@@ -1066,8 +1039,7 @@ permalink: /about/
 
 Let's rename the layout to `default`. Functionally, it doesn't make a difference what we name it, as long as there's a layout file with the same name. It's just that `default` is more idiomatic—it's our website's "default layout."
 
-{% include codeHeader.html file: "_pages/about.md" %}
-```markdown
+```markdown {data-file="_pages/about.md" data-copyable=true}
 ---
 layout: default
 title: About
@@ -1077,8 +1049,7 @@ permalink: /about/
 
 Let's do the same for `_pages/index.md` and give the page a title as well, while we're at it:
 
-{% include codeHeader.html file: "_pages/index.md" %}
-```markdown
+```markdown {data-file="_pages/index.md" data-copyable=true}
 ---
 layout: default
 title: Home
@@ -1092,9 +1063,8 @@ This is the home page.
 
 Let's also create two other pages, `blog.md` and `contact.md`:
 
-{% include codeHeader.html file: "_pages/blog.md" %}
 {% raw %}
-```markdown
+```markdown {data-file="_pages/blog.md" data-copyable=true}
 ---
 layout: default
 title: Blog
@@ -1111,8 +1081,7 @@ permalink: /blog
 ```
 {% endraw %}
 
-{% include codeHeader.html file: "_pages/contact.md" %}
-```markdown
+```markdown {data-file="_pages/contact.md" data-copyable=true}
 ---
 layout: default
 title: Contact
@@ -1130,9 +1099,8 @@ Get in touch!
 
 Next, create the `_layouts/` directory and add a file to it named `default.html` with these contents:
 
-{% include codeHeader.html file: "_layouts/default.html" %}
 {% raw %}
-```html
+```html {data-file="_layouts/default.html" data-copyable=true}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1168,8 +1136,7 @@ The most important part is {% raw %}`{{ content }}`{% endraw %}, which you shoul
 
 One final note: If you want to change the site title that appears after the dash in the address bar, then simply change that variable in your `_config.yml` as I mentioned before:
 
-{% include codeHeader.html file: "_config.yml" %}
-```yml
+```yml {data-file="_config.yml" data-copyable=true}
 # Site settings
 # These are used to personalize your new site. If you look in the HTML files,
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
@@ -1182,8 +1149,7 @@ title: Your awesome title
 
 If you open up the starter blog post that we saw earlier, you'll notice that it has a different layout set:
 
-{% include codeHeader.html file: "_posts/2020-02-14-welcome-to-jekyll.markdown", copyable: false %}
-```markdown
+```markdown {data-file="_posts/2020-02-14-welcome-to-jekyll.markdown"}
 ---
 layout: post
 title:  "Welcome to Jekyll!"
@@ -1197,9 +1163,8 @@ The blog post collapses to a "flat" layout and doesn't have the same HTML struct
 
 This is because the `post` layout doesn't exist. Let's go ahead and create this layout file. This time around, you'll notice that a layout file can itself specify a layout:
 
-{% include codeHeader.html file: "_layouts/post.html" %}
 {% raw %}
-```html
+```html {data-file="_layouts/post.html" data-copyable=true}
 ---
 layout: default
 ---
@@ -1253,8 +1218,7 @@ Notice that we reference the compiled version (`.css`) that's going to live unde
 
 Meanwhile, this is what my manifest looks like:
 
-{% include codeHeader.html file: "/assets/styles/main.scss" %}
-```sass
+```sass {data-file="/assets/styles/main.scss" data-copyable=true}
 ---
 ---
 
@@ -1309,8 +1273,7 @@ Creating modular stylesheets and importing them into a SASS manifest makes it mu
 
 Let's give this a shot. Create a file named `_sass/_general.scss` with this styling (or really anything you want):
 
-{% include codeHeader.html file: "_sass/_general.scss" %}
-```scss
+```scss {data-file="_sass/_general.scss" data-copyable=true}
 * {
   box-sizing: border-box;
   margin: 0;
@@ -1325,8 +1288,7 @@ body {
 
 And then create this file:
 
-{% include codeHeader.html file: "assets/styles/main.scss" %}
-```scss
+```scss {data-file="assets/styles/main.scss" data-copyable=true}
 ---
 ---
 
@@ -1342,8 +1304,7 @@ _site/assets/styles
 
 Here's what the transpiled, minified stylesheet looks like:
 
-{% include codeHeader.html file: "_site/assets/styles/main.css", copyable: false %}
-```css
+```css {data-file="_site/assets/styles/main.css"}
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body { font-size: 18px; font-family: Arial; }
@@ -1351,8 +1312,7 @@ body { font-size: 18px; font-family: Arial; }
 
 Finally, don't forget to link the stylesheet to your `default.html` layout. Just add this to your `head`:
 
-{% include codeHeader.html file: "_layouts/default.html" %}
-```html
+```html {data-file="_layouts/default.html" data-copyable=true}
 <link rel="stylesheet" type="text/css" href="/assets/styles/main.css">
 ```
 
@@ -1366,9 +1326,7 @@ Need to add more styles? Simply create a new SASS stylesheet under `_sass/`, pos
 
 Minifying CSS is one of the many things you can do to improve your page load speed. And fortunately, doing so is really easy in Jekyll. All you have to do is add this somewhere in your `_config.yml`:
 
-{% include codeHeader.html file: "_config.yml" %}
-```yaml
-
+```yaml {data-file="_config.yml" data-copyable=true}
 sass:
   style: compressed
 ```
@@ -1385,9 +1343,8 @@ Includes are created under the `_includes/` directory. An include file is simply
 
 For example, let's say you want to use tooltips on your site but don't want to have to copy-paste the same HTML each time you want to use one on a page. This is a perfect use case for includes:
 
-{% include codeHeader.html file: "_includes/tooltip.html" %}
 {% raw %}
-```html
+```html {data-file="_includes/tooltip.html" data-copyable=true}
 <div class="tooltip tooltip-{{ include.position }}">
     <div class="tooltip-text">
         {{ include.text }}
@@ -1398,9 +1355,8 @@ For example, let's say you want to use tooltips on your site but don't want to h
 
 Here's how we might include a tooltip in another file:
 
-{% include codeHeader.html %}
 {% raw %}
-```liquid
+```liquid {data-copyable=true}
 {% include tooltip.html position="top" text="This is a tooltip!" %}
 ```
 {% endraw %}
@@ -1467,8 +1423,7 @@ You can then loop over that data using Liquid tags and finally give the data its
 
 Let's say you have a simple file named `_data/skills.yml`. Suppose it looks something like this:
 
-{% include codeHeader.html file: "_data/skills.yml" %}
-```yml
+```yml {data-file="_data/skills.yml" data-copyable=true}
 - name: Writing
   rating: 5
 - name: Jekyll
@@ -1479,9 +1434,8 @@ Let's say you have a simple file named `_data/skills.yml`. Suppose it looks some
 
 You can access this data using `site.data.skills`. If your YAML defines an array of skills like above, you can iterate over it and define template markup for each element:
 
-{% include codeHeader.html file: "_pages/experience.md" %}
 {% raw %}
-```liquid
+```liquid {data-file="_pages/experience.md" data-copyable=true}
 <ul>
     {% for skill in site.data.skills %}
     <li class="skill">{{ skill.name }} - {{ skill.rating }}</li>
@@ -1494,8 +1448,7 @@ This is a fairly simple example—in reality, you'd probably want to do more tha
 
 Also, note that you can nest arrays in YAML and in Liquid. This would allow you to, for example, define skill *categories* and nest the actual skills within them:
 
-{% include codeHeader.html file: "_data/skills.yml" %}
-```yml
+```yml {data-file="_data/skills.yml" data-copyable=true}
 - category: Blogging
   skills:
     - name: Writing
@@ -1513,9 +1466,8 @@ Also, note that you can nest arrays in YAML and in Liquid. This would allow you 
 
 And again, we can give this data more structure:
 
-{% include codeHeader.html file: "_pages/experience.md" %}
 {% raw %}
-```liquid
+```liquid {data-file="_pages/experience.md" data-copyable=true}
 {% for item in site.data.skills %}
 <h4>{{ item.category }}</h4>
 <ul>
@@ -1533,8 +1485,7 @@ Now let's suppose you run a blog that has multiple authors, not just you.
 
 You can create a data file for each author and define the path to their profile photo, their name, their bio, and a fixed set of social media links, like Twitter, GitHub, and whatnot:
 
-{% include codeHeader.html file: "_data/authors.yml" %}
-```yml
+```yml {data-file="_data/authors.yml" data-copyable=true}
 John Doe:
   photo: john-doe.JPG
   bio: John is a... Well, we don't actually know what he does. Actually, we're not even sure we know who he is.
@@ -1558,9 +1509,8 @@ Notice how your Jekyll data files can be as complex as you need, with nested arr
 
 Let's assume each post defines an author in its front matter:
 
-{% include codeHeader.html file: "_posts/2020-02-13-a-really-awesome-post.md" %}
 {% raw %}
-```markdown
+```markdown {data-file="_posts/2020-02-13-a-really-awesome-post.md" data-copyable=true}
 ---
 title: A Really Awesome Post
 author: Jane Doe
@@ -1575,9 +1525,8 @@ The end!
 
 We can now add a bio at the end of each post, ideally in the `post.html` layout file so we don't have to repeat it for every single post that we publish:
 
-{% include codeHeader.html file: "_layouts/post.html" %}
 {% raw %}
-```html
+```html {data-file="_layouts/post.html" data-copyable=true}
 ---
 layout: default
 ---
@@ -1617,8 +1566,7 @@ Now you want to assign descriptions to each tag to dynamically update a page's d
 
 Create a data file named `tagDescriptions.yml` (or something else) and define key-value pairs in the YAML, where the key is the tag name and the value is the description for that particular tag:
 
-{% include codeHeader.html file: "_data/tagDescriptions.yml" %}
-```yml
+```yml {data-file="_data/tagDescriptions.yml" data-copyable=true}
 dev: Technical posts. Yay dev!
 life: As in, the thing I like to pretend to have...
 tag: This is a tag. How exciting!
@@ -1626,9 +1574,8 @@ tag: This is a tag. How exciting!
 
 Then, you can once again take advantage of YAML's associative data nature to assign descriptions to each tag:
 
-{% include codeHeader.html file: "_layouts/blog.html" %}
 {% raw %}
-```html
+```html {data-file="_layouts/blog.html" data-copyable=true}
 {% for tag in site.tags %}
 <a
     class="tag"

--- a/src/_posts/2020-03-11-how-to-add-a-copy-to-clipboard-button-to-your-jekyll-blog.md
+++ b/src/_posts/2020-03-11-how-to-add-a-copy-to-clipboard-button-to-your-jekyll-blog.md
@@ -20,8 +20,7 @@ At a high level, all we need is a simple include file that we can stick in front
 
 ### 1. Copy-to-Clipboard Include: `_includes/codeHeader.html`
 
-{% include codeHeader.html file: "_includes/codeHeader.html" %}
-```html
+```html {data-file="_includes/codeHeader.html" data-copyable=true}
 <div class="code-header">
     <button class="copy-code-button" aria-label="Copy code to clipboard"></button>
 </div>
@@ -44,8 +43,7 @@ This just renders a normal fenced code block (with triple backticks). Right befo
 
 Below is some CSS to get you started (I'm using SCSS). Styling this to make it look pretty is up to you, so I've omitted colors and font sizes.
 
-{% include codeHeader.html %}
-```scss
+```scss {data-copyable=true}
 .code-header {
   display: flex;
   justify-content: flex-end;
@@ -94,8 +92,7 @@ We'll look up two arrays, side by side:
 
 Here's the code:
 
-{% include codeHeader.html file: "assets/scripts/copyCode.js" %}
-```javascript
+```javascript {data-file="assets/scripts/copyCode.js" data-copyable=true}
 const codeBlocks = document.querySelectorAll('.code-header + .highlighter-rouge');
 const copyCodeButtons = document.querySelectorAll('.copy-code-button');
 
@@ -121,8 +118,7 @@ Finally, the copy-to-clipboard button uses CSS pseudo-elements to show `Copy ðŸ“
 
 That's it! Don't forget to add a script tag so this code actually works. For example, you can stick this somewhere in your layout file for blog posts:
 
-{% include codeHeader.html file: "_layouts/post.html" %}
-```html
+```html {data-file="_layouts/post.html" data-copyable=true}
 <script src="/assets/scripts/copyCode.js"></script>
 ```
 

--- a/src/_posts/2020-04-04-seo-blogging-tips.md
+++ b/src/_posts/2020-04-04-seo-blogging-tips.md
@@ -237,8 +237,7 @@ Google already relies on the structure of your page—your title tag, the descri
 
 But you can also include **schema markup** in your HTML to inform search engines of the type of content you've published and any of its particular details, such as the headline, the author, the date published or modified, and so on. Here's an example from [Google's docs on structured data](https://developers.google.com/search/docs/data-types/article#examples):
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -276,9 +275,8 @@ Simply stick this anywhere in your HTML for each blog post that you publish.
 
 If you're using a static site generator like Gatsby or Jekyll, you should be able to define this as a template in one place so you don't have to copy-paste it for every single blog post. For example, my website was built with Jekyll, and I have the following in my `_layouts/post.html` layout file:
 
-{% include codeHeader.html file: "_layouts/post.html" %}
 {% raw %}
-```html
+```html {data-file="_layouts/post.html" data-copyable=true}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/src/_posts/2020-04-20-javascript-pass-by-reference.md
+++ b/src/_posts/2020-04-20-javascript-pass-by-reference.md
@@ -83,8 +83,7 @@ By analogy, a reference is like a person's nickname. My real name is Aleksandr, 
 
 Here's some C++ code to illustrate true reference variables in action:
 
-{% include codeHeader.html %}
-```cpp
+```cpp {data-copyable=true}
 #include <iostream>
 #include <string>
 
@@ -107,8 +106,7 @@ int main()
 
 In languages that don't support reference variables (e.g., JavaScript), two variables may share **a copy** of a value, but it's guaranteed that those variables will **occupy different memory addresses**. Here's an attempt at the above in JavaScript:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 let myName = "Aleksandr";
 let myNickname = myName;
 
@@ -124,8 +122,7 @@ On the second line, what I'm doing is creating a copy of the string `"Aleksandr"
 
 Unlike a variable that receives a copy of a value, [a reference variable does not have its own memory address](https://stackoverflow.com/a/1950998/10480032)—it shares the same exact memory address as the original variable. Strange, isn't it? We can verify this in C++ using something called the address-of operator (`&`), which returns the memory address of a variable:
 
-{% include codeHeader.html %}
-```cpp
+```cpp {data-copyable=true}
 #include <iostream>
 #include <string>
 
@@ -248,8 +245,7 @@ In **pass by reference**, the formal parameter is a reference variable (alias) f
 
 There's a classic **litmus test** to check if a language supports passing by reference: whether you can swap two numbers (the following code is written in JavaScript):
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 function swap(a, b) {
     const temp = a;
     a = b;

--- a/src/_posts/2020-05-10-responsive-navbar-without-bootstrap.md
+++ b/src/_posts/2020-05-10-responsive-navbar-without-bootstrap.md
@@ -38,9 +38,7 @@ We'll design this with a mobile-first approach and simply take care of the deskt
 
 Below is all of the HTML that we're going to need to create our responsive navbar:
 
-{% include codeHeader.html file: "index.html" %}
-
-```html
+```html {data-file="index.html"}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -126,9 +124,7 @@ We're going to take this slowly. I'll add explanations for each bit of CSS and J
 
 First up are some standard CSS resets and base styling:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 :root {
   --navbar-bg-color: hsl(0, 0%, 15%);
   --navbar-text-color: hsl(0, 0%, 85%);
@@ -153,9 +149,7 @@ Feel free to remove any of the CSS that doesn't apply to your situation; this is
 
 Before we look at the CSS specific to the responsive navbar, I'd like to introduce one more selector:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .container {
   max-width: 1000px;
   padding: 0 1.4rem;
@@ -171,9 +165,7 @@ This is a pretty popular approach for centering things horizontally in CSS. Basi
 
 Alright, time to actually style our responsive navbar. We'll work in a top-down fashion. First up is the outermost `#navbar` element:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 #navbar {
   --navbar-height: 64px;
   position: fixed;
@@ -193,9 +185,7 @@ Why we need the CSS variable will become obvious later on. The entire element is
 
 Moving on, we have the nested container element:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .navbar-container {
   display: flex;
   justify-content: space-between;
@@ -212,9 +202,7 @@ As I mentioned earlier, this is simply a flex container. We use `justify-content
 
 Next up is some general styling for the navbar anchors:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .navbar-item {
   margin: 0.4em;
   width: 100%;
@@ -254,9 +242,7 @@ Pretty straightforward.
 
 Here's the CSS for the website logo. Note that this is just a placeholder for my demo; in reality, you'll probably want to use an image or SVG:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .navbar-logo {
   background-color: var(--navbar-text-color-focus);
   border-radius: 50%;
@@ -301,9 +287,7 @@ That's all that you need to create a semantic and accessible toggle button.
 
 Let's now look at some of the CSS:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 #navbar-toggle {
   cursor: pointer;
   border: none;
@@ -321,9 +305,7 @@ We reset some of the default button styles and give it fixed dimensions. It's al
 
 Here's the CSS for the icon bars:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .icon-bar {
   display: block;
   width: 25px;
@@ -345,9 +327,7 @@ There are lots of ways to do this, but I think this is the most straightforward 
 
 When the toggle button is clicked, we'll set `aria-expanded` to `"true"` on the button. Here's how we'll animate the hamburger icon to become a close icon (X):
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 #navbar-toggle[aria-expanded='true'] .icon-bar:is(:first-child, :last-child) {
   position: absolute;
   margin: 0;
@@ -373,9 +353,7 @@ The middle bar disappears, the top and bottom bars get centered, the top bar rot
 
 Now's a good time to code up the logic for toggling the navigation menu so we can test that the toggle button works. Ideally, you'd want to put this in a separate module to avoid leaking variables into the global scope, or wrap the whole thing in an immediately invoked function expression the old-fashioned way.
 
-{% include codeHeader.html file: "index.js" %}
-
-```javascript
+```javascript {data-file="index.js"}
 const navbarToggle = navbar.querySelector('#navbar-toggle');
 let isNavbarExpanded = navbarToggle.getAttribute('aria-expanded') === 'true';
 
@@ -402,9 +380,7 @@ At this point, you can open up your browser and test out the button. The menu it
 
 As I mentioned earlier, the navigation menu wrapper has fixed positioning, with a `top` offset equal to precisely the height of the navbar itself:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 #navbar-menu {
   position: fixed;
   top: var(--navbar-height);
@@ -424,9 +400,7 @@ While `opacity: 0` and `visibility: hidden` may seem redundant, it's a good prac
 
 Below is the CSS for the menu's open state; we style it based on whether it's a sibling of the toggle button in the `aria-expanded="true"` state:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 #navbar-toggle[aria-expanded='true'] + #navbar-menu {
   background-color: rgba(0, 0, 0, 0.4);
   opacity: 1;
@@ -440,9 +414,7 @@ Click the hamburger icon to see the following result:
 
 The container for the navigation links is an unordered list:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .navbar-links {
   list-style: none;
   position: absolute;
@@ -468,9 +440,7 @@ The container for the navigation links is an unordered list:
 
 This is the actual, physical "menu" part of our navigation. The margin ensures that the menu appears detached from the rest of the navbar, as if it's floating on the page. If instead you'd like it to appear as a physical extension of the navigation bar, simply get rid of the margin and border radius and shift the shadow down:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 .navbar-links {
   list-style: none;
   position: absolute;
@@ -492,9 +462,7 @@ And that's it for the mobile version's CSS!
 
 One last thing before we style the desktop version. Add this to your JavaScript:
 
-{% include codeHeader.html file: "index.js" %}
-
-```javascript
+```javascript {data-file="index.js"}
 const navbarMenu = document.querySelector('#navbar-menu');
 const navbarLinksContainer = navbarMenu.querySelector('.navbar-links');
 
@@ -510,9 +478,7 @@ Go ahead and test this on your end to make sure the mobile version works.
 
 I'll show the media query in its entirety and then we'll look at what each piece is doing:
 
-{% include codeHeader.html file: "style.css" %}
-
-```css
+```css {data-file="style.css"}
 @media screen and (min-width: 700px) {
   #navbar-toggle,
   #navbar-toggle[aria-expanded='true'] {

--- a/src/_posts/2020-06-01-github-pages-vs-netlify.md
+++ b/src/_posts/2020-06-01-github-pages-vs-netlify.md
@@ -101,8 +101,7 @@ If one of your URLs changes, Google will need to know that the old and new versi
 
 On the other hand, redirects in Netlify are [super easy to set up](https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file). All you need to do is create a plaintext `_redirects` file that maps old URLs to new ones, separating the two with a tab:
 
-{% include codeHeader.html file: "_redirects" %}
-```
+``` {data-file="_redirects" data-copyable=true}
 /old-url/   /new-url/
 /another-old-url /another-new-url
 ```

--- a/src/_posts/2020-06-06-binary-for-beginners.md
+++ b/src/_posts/2020-06-06-binary-for-beginners.md
@@ -157,8 +157,7 @@ Everything on your computer—the files you save and the software you install—
 
 Suppose you create a file on your computer and store some basic text in it:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 echo Hello, Binary > file
 ```
 
@@ -214,8 +213,7 @@ The key takeaway here is that we only need one byte to store one character on a 
 
 Remember the file we created earlier? Let's view its binary representation using the <code>xxd</code> Unix tool:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 xxd -b file
 ```
 

--- a/src/_posts/2020-07-01-simple-webpack-config.md
+++ b/src/_posts/2020-07-01-simple-webpack-config.md
@@ -27,15 +27,13 @@ And all you want is a simple webpack config that creates a single bundled JavaSc
 
 First, install webpack if you haven't already done so:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 yarn add -D webpack webpack-cli
 ```
 
 Once that's done, add this script to your `package.json`:
 
-{% include codeHeader.html file: "package.json" %}
-```json
+```json {data-file="package.json" data-copyable=true}
 "scripts": {
     "build": "webpack --config config/webpack.config.js --mode production"
 }
@@ -43,8 +41,7 @@ Once that's done, add this script to your `package.json`:
 
 And then create this simple webpack config under `config/`:
 
-{% include codeHeader.html file: "webpack.config.js" %}
-```javascript
+```javascript {data-file="webpack.config.js" data-copyable=true}
 const path = require('path');
 
 module.exports = {
@@ -89,8 +86,7 @@ Done in 2.47s.
 
 Now you can include the bundled code in your HTML file:
 
-{% include codeHeader.html file: "index.html" %}
-```html
+```html {data-file="index.html" data-copyable=true}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -112,8 +108,7 @@ Relative imports can get pretty nasty: `import X from '../../../'`.
 
 To use absolute imports in webpack, we'll set up import aliases. Here's the new webpack config:
 
-{% include codeHeader.html file: "config/webpack.config.js" %}
-```javascript
+```javascript {data-file="config/webpack.config.js" data-copyable=true}
 const path = require('path');
 
 module.exports = {
@@ -147,8 +142,7 @@ import Module from 'components/Module';
 
 If you're using VS Code, you can take this one step further and create a `jsconfig.json`:
 
-{% include codeHeader.html file: "jsconfig.json" %}
-```json
+```json {data-file="jsconfig.json" data-copyable=true}
 {
     "compilerOptions": {
         "baseUrl": "./src/",

--- a/src/_posts/2020-07-03-sass-multiple-transitions-mixin.md
+++ b/src/_posts/2020-07-03-sass-multiple-transitions-mixin.md
@@ -30,8 +30,7 @@ $transition: 0.2s ease;
 
 But that still doesn't fully eliminate the repetition—we just have to type fewer characters now. What I was searching for is a **Sass mixin for multiple CSS transitions**. And I eventually found it in [a StackOverflow answer by user yspreen](https://stackoverflow.com/a/49437769/5323344):
 
-{% include codeHeader.html file: "mixins.scss" %}
-```scss
+```scss {data-file="mixins.scss" data-copyable=true}
 @mixin transition($props...) {
     $result: ();
 

--- a/src/_posts/2020-07-09-jekyll-comment-system-github-issues.md
+++ b/src/_posts/2020-07-09-jekyll-comment-system-github-issues.md
@@ -32,8 +32,7 @@ This section is a bit of a recap on how to use the GitHub Issues API to add comm
 
 First, you'll need a public repo for your comments. Add this variable to your `_config.yml`:
 
-{% include codeHeader.html file: "_config.yml" %}
-```yml
+```yml {data-file="_config.yml" data-copyable=true}
 issues_repo: YourUsername/RepoName
 ```
 
@@ -47,16 +46,14 @@ If a particular blog post needs comments, open an issue for it in that repo and 
 
 Add the following front matter variable to the blog post for which you want to enable comments; assign it the ID from above:
 
-{% include codeHeader.html file: "_posts/2020-07-07-my-post.md" %}
-```markdown
+```markdown {data-file="_posts/2020-07-07-my-post.md" data-copyable=true}
 comments_id: 35
 ```
 
 In your `post.html` layout file, check to see if this front matter variable was specified. If it wasn't, then the comment system is turned off for that particular post. If it was defined, then we'll want to include a file containing our HTML and JavaScript for the comment system:
 
-{% include codeHeader.html file: "_layouts/post.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="_layouts/post.html" data-copyable=true}
 {% if page.comments_id %}
   {% include comments.html issue_id=page.comments_id %}
 {% endif %}
@@ -65,9 +62,8 @@ In your `post.html` layout file, check to see if this front matter variable was 
 
 And here's the include file itself (or at least part of it—we'll fill in the script shortly):
 
-{% include codeHeader.html file: "_includes/comments.html" %}
 {% raw %}
-```html
+```html {data-file="_includes/comments.html" data-copyable=true}
 {% assign issues_repo = site.issues_repo %}
 {% assign issue_id = include.issue_id %}
 
@@ -104,9 +100,8 @@ Time to start writing some JavaScript!
 
 First, we'll create some variables up at the top to reference a few of the elements on the page:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
 {% raw %}
-```html
+```html {data-file="_includes/comments.html" data-copyable=true}
 <script>
   const commentsSection = document.getElementById('comments');
   const commentsWrapper = commentsSection.querySelector('#comments-wrapper');
@@ -127,8 +122,7 @@ If you load the comment system every time a user visits one of your blog posts, 
 
 To detect when a user has scrolled to the end of the page, we'll use the widely supported [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). Here's all the code that we need to defer loading the comments section:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
-```javascript
+```javascript {data-file="_includes/comments.html" data-copyable=true}
 const commentsObserver = new IntersectionObserver((entries, self) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting) {
@@ -145,9 +139,8 @@ The observer checks to see if it's intersecting with the `commentsSection` eleme
 
 Here's the `fetchComments` function that fires when an intersection occurs:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
 {% raw %}
-```javascript
+```javascript {data-file="_includes/comments.html" data-copyable=true}
 const fetchComments = async () => {
   try {
     const comments = await (await fetch(
@@ -198,8 +191,7 @@ There are two approaches you can take to defer loading your dependencies: using 
 
 My site currently takes the first approach. However, to keep this post accessible to most readers, I'll take the second approach since not everyone is using Webpack to bundle their JavaScript. We'll create `script` elements, set their `src` attributes, and append them to the DOM body. Here's a function that'll do that for us, given a `src`:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
-```javascript
+```javascript {data-file="_includes/comments.html" data-copyable=true}
 const loadScript = (src) => {
   const scriptElement = document.createElement('script');
   document.body.appendChild(scriptElement);
@@ -217,8 +209,7 @@ This function creates a script element and registers an `onload` listener for it
 
 Now, we'll need some way to hold off on rendering comments until *all* of the dependencies have loaded. To do that, we'll use a simple array of scripts to load and take advantage of [`Promise.all`](/blog/javascript-promise-all/), together with the async function we just wrote:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
-```javascript
+```javascript {data-file="_includes/comments.html" data-copyable=true}
 const commentScripts = [
   'https://unpkg.com/marked@0.3.6/marked.min.js',
   'https://unpkg.com/dompurify@1.0.8/dist/purify.min.js',
@@ -255,9 +246,8 @@ Before we move on, I want to reiterate: If all of this seems weird and hacky, th
 
 We've loaded all of our dependencies, either using Promises like I showed above or with dynamic imports and a module bundler that can load the chunks at runtime. Now that our dependencies are ready to use, the only task that remains is actually rendering the comments:
 
-{% include codeHeader.html file: "_includes/comments.html" %}
 {% raw %}
-```javascript
+```javascript {data-file="_includes/comments.html" data-copyable=true}
 const renderComments = (comments) => {
   // load the relativeTime plugin for dayjs so we can express dates relative to now
   dayjs.extend(dayjs_plugin_relativeTime);

--- a/src/_posts/2020-07-12-test-localhost-on-mobile.md
+++ b/src/_posts/2020-07-12-test-localhost-on-mobile.md
@@ -36,8 +36,7 @@ Check out the [ngrok documentation on how to get started](https://dashboard.ngro
 
 Once you've set up ngrok, using it is a piece of cake. If you've spun up a simple web server on a localhost port (e.g., `jekyll`), simply run this command from your terminal to expose it as a public URL:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 ngrok http portNumber
 ```
 
@@ -57,8 +56,7 @@ As a bonus, this means that you can also share your localhost changes with other
 
 If you'd like to, you can also enforce a username and password combo when testing localhost on mobile so that only people with those secret credentials can access your URL:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 ngrok http -auth "user:password" portNumber
 ```
 

--- a/src/_posts/2020-07-26-what-are-cookies.md
+++ b/src/_posts/2020-07-26-what-are-cookies.md
@@ -117,8 +117,7 @@ Now, if you inspect future requests, this cookie will be included in the **`Cook
 
 Before we move on, note that there's a second way to view cookies in your developer tools. Navigate to the `Console` tab, enter the following code, and press enter:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 document.cookie
 ```
 
@@ -126,8 +125,7 @@ You'll see one big output string containing `name=value` pairs of cookies strung
 
 Here's an example of creating a cookie with JavaScript:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 document.cookie = 'foo=bar'
 ```
 
@@ -139,8 +137,7 @@ Note that you can't create multiple cookies in one go, like `document.cookie = '
 
 When you just specify the name and value of a cookie, it gets created as a session cookie by default. You can also optionally specify an expiration:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 document.cookie = 'foo=bar; expires=Su, 20 Dec 2020 20:20:20 UTC'
 ```
 
@@ -150,8 +147,7 @@ document.cookie = 'foo=bar; expires=Su, 20 Dec 2020 20:20:20 UTC'
 
 To delete a cookie with JavaScript, you need to set its expiration date to be sometime in the past:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 document.cookie = 'foo=bar; expires=Fri, 24 Jul 2020 04:00:00 UTC'
 ```
 

--- a/src/_posts/2020-08-01-jekyll-table-of-contents.md
+++ b/src/_posts/2020-08-01-jekyll-table-of-contents.md
@@ -15,9 +15,8 @@ Alright, let's cut to the chase: You want to create a table of contents in Jekyl
 
 Create an include file named `toc.md` and fill it with this markup:
 
-{% include codeHeader.html file: "_includes/toc.md" %}
 {% raw %}
-```markdown
+```markdown {data-file="_includes/toc.md" data-copyable=true}
 <div style="position: relative;">
     <a href="#toc-skipped" class="screen-reader-only">Skip table of contents</a>
 </div>
@@ -50,9 +49,8 @@ The following markup just creates a `Table of Contents` heading level two that's
 
 Then, in your post, all you have to do is insert this one-liner wherever you want your table of contents to appear:
 
-{% include codeHeader.html %}
 {% raw %}
-```liquid
+```liquid {data-copyable=true}
 {% include toc.md %}
 ```
 {% endraw %}
@@ -85,8 +83,7 @@ One last thing: You typically don't want "skip to content" links like this to be
 
 So, here's the Sass that'll get the job done:
 
-{% include codeHeader.html file: "_sass/someSassFile.scss" %}
-```scss
+```scss {data-file="_sass/someSassFile.scss" data-copyable=true}
 .screen-reader-only {
     position: absolute;
     left: -5000px;

--- a/src/_posts/2020-08-09-sorting-ant-design-tables.md
+++ b/src/_posts/2020-08-09-sorting-ant-design-tables.md
@@ -15,8 +15,7 @@ Want to sort tables in Ant Design but without putting in much effort? Then you'r
 
 The Ant Design docs for the `Table` component use this example for [multi-sorting columns](https://ant.design/components/table/#components-table-demo-multiple-sorter):
 
-{% include codeHeader.html %}
-```jsx
+```jsx {data-copyable=true}
 import { Table } from 'antd';
 
 const columns = [
@@ -144,8 +143,7 @@ Can we do better? (Hint: Of course we can!)
 
 It's always a good idea to create wrapper components in React whenever you're customizing the behavior or appearance of a library component, especially if you're working with Ant Design. So we'll go ahead and create our own `Table` component like so:
 
-{% include codeHeader.html file: "components/Table" %}
-```jsx
+```jsx {data-file="components/Table" data-copyable=true}
 import React from 'react';
 import { Table as AntTable } from 'antd';
 
@@ -162,8 +160,7 @@ For our purposes, we want to sort Ant Design tables with ease, automating the pr
 
 We'll start by creating a utility file (e.g., `utils/sorter.js`) that defines a few generic sorting routines. Two common use cases that you'll run into with sorting Ant Design columns are 1) text/numeric columns and 2) date columns. These should be handled separately; the latter will use the `moment` library. Feel free to use another library if you want to.
 
-{% include codeHeader.html file: "utils/sorter.js" %}
-```javascript
+```javascript {data-file="utils/sorter.js" data-copyable=true}
 import moment from 'moment';
 
 /**
@@ -186,8 +183,7 @@ const defaultSort = (a, b) => {
 
 Short and sweet. We'll then export an object that defines two generic lookup properties—`Sorter.DEFAULT` and `Sorter.DATE`:
 
-{% include codeHeader.html file: "utils/sorter.js" %}
-```javascript
+```javascript {data-file="utils/sorter.js" data-copyable=true}
 export const Sorter = {
   DEFAULT: defaultSort,
   DATE: dateSort,
@@ -200,8 +196,7 @@ We'll use this in a second.
 
 Let's revisit our "consumer" component, where the table is being rendered. We'll change the import to use our custom Table component:
 
-{% include codeHeader.html file: "app/consumer.js" %}
-```jsx
+```jsx {data-file="app/consumer.js" data-copyable=true}
 import Table from 'components/Table'
 ```
 
@@ -211,8 +206,7 @@ import Table from 'components/Table'
 
 We'll want to specify the sorting routine for every column that needs to be sorted. We'll do this by simply referencing the generic enum that we exported above:
 
-{% include codeHeader.html file: "app/consumer.js" %}
-```jsx
+```jsx {data-file="app/consumer.js" data-copyable=true}
 const columns = [
   {
     title: 'Name',
@@ -273,8 +267,7 @@ By definition, our wrapper component will receive props just like a traditional 
 
 What we'll do is write a [shim](https://stackoverflow.com/a/51646150/5323344)—some code that will basically intercept the `columns` prop, map it to a new `sortableColumns` prop that defines the sorter routine by dynamically looking up the current column's `dataIndex`, and then pass *that* result along to the table's `columns` prop:
 
-{% include codeHeader.html file: "components/Table.js" %}
-```jsx
+```jsx {data-file="components/Table.js" data-copyable=true}
 import React from 'react';
 import { Table as AntTable } from 'antd';
 

--- a/src/_posts/2020-09-01-optimizing-images-for-the-web.md
+++ b/src/_posts/2020-09-01-optimizing-images-for-the-web.md
@@ -59,8 +59,7 @@ Outside the Node ecosystem, there are still libraries that'll do the job for you
 
 Now, assuming that you've generated your WebP images, the typical way to render them is with the `<picture>`, `<source>`, and `<img>` tags::
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <picture>
   <source
     srcset="/path/to/img.webp"
@@ -118,8 +117,7 @@ The second option is to use the **IntersectionObserver API**, which allows you t
 
 For example, your modified markup might end up looking something like this. Note how the `srcset` and `src` point to placeholder images, while `data-srcset` and `data-src` point to the real WebP and JPEG images, respectively.
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <picture class="lazy-picture">
   <source
     srcset="/path/to/img-placeholder.webp"
@@ -137,8 +135,7 @@ I'm naming these attributes `data-srcset` and `data-src`, respectively, but you 
 
 Next, we'll create an `IntersectionObserver` instance and use it to detect when our images intersect with the browser viewport:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const imgObserver = new IntersectionObserver((entries, self) => {
   entries.forEach(entry => {
     if (entry.isIntersecting) {
@@ -154,8 +151,7 @@ document.querySelectorAll('.lazy-picture').forEach((picture) => {
 
 And here's how you might implement the `lazyLoad` function:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const lazyLoad = (picture) => {
   const img = picture.querySelector('img');
   const sources = picture.querySelectorAll('source');

--- a/src/_posts/2020-09-12-javascript-promise-tricks.md
+++ b/src/_posts/2020-09-12-javascript-promise-tricks.md
@@ -22,8 +22,7 @@ Sometimes, you'll find yourself working on a front-end feature for which an API 
 
 Now, you *could* just hard-code your data in the UI, like mapping a fixed array of objects to some HTML output (either with vanilla JavaScript or, in this case, React):
 
-{% include codeHeader.html file: "App.js" %}
-```jsx
+```jsx {data-file="App.js" data-copyable=true}
 import React from 'react';
 
 const BookList = ({ books }) => {
@@ -67,8 +66,7 @@ While it's tempting to take this route, it's not a good idea because it neglects
 
 The solution? Use Promises to create a mock API in your frontend:
 
-{% include codeHeader.html file: "utils/getData.js" %}
-```javascript
+```javascript {data-file="utils/getData.js" data-copyable=true}
 export const getData = (data, successRate = 0.98, maxLatencyMs = 1000) =>
   new Promise((resolve, reject) => {
     const successRoll = Math.random();
@@ -87,8 +85,7 @@ This function accepts one required argument: your fake data. The remaining argum
 
 Now, instead of hardcoding data in our frontend, we can pass along our fake data to the mock API, which will either bounce it back to us after some time or fail:
 
-{% include codeHeader.html file: "App.js" %}
-```jsx
+```jsx {data-file="App.js" data-copyable=true}
 import React, { useState, useEffect } from "react";
 
 const BookList = ({ books }) => {
@@ -145,8 +142,7 @@ Older JavaScript APIs (e.g., the now-deprecated [request](https://github.com/req
 
 Here's a simulated callback using a simple `setTimeout`:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 function doSomething(arg1, callback) {
   // In reality, the function would do something else and then
   // invoke the callback. The timeout is for demo purposes.
@@ -202,8 +198,7 @@ Our `getSetting` function takes two arguments: the key to use for looking up dat
 
 To convert this to a simpler Promise-based syntax, we just create our own wrapper function that returns a Promise and either resolves or rejects, depending on the result of `getSetting`:
 
-{% include codeHeader.html file: "getSettingAsync.js" %}
-```javascript
+```javascript {data-file="getSettingAsync.js" data-copyable=true}
 function getSettingAsync(key) {
     return new Promise((resolve, reject) => {
         try {
@@ -219,8 +214,7 @@ function getSettingAsync(key) {
 
 That's it! Now, we can just do this:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 getSettingAsync('foo')
   .then(console.log)
   .catch(e => setErrorState(true));
@@ -238,8 +232,7 @@ For whatever reason, let's say you need to load a script (or image, or any other
 
 The naive approach uses nested `onload` handlers, like so:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const script1 = document.createElement('script');
 const script2 = document.createElement('script');
 const script3 = document.createElement('script');
@@ -281,8 +274,7 @@ But the nesting only gets worse from here, and there's already a lot of hard-cod
 
 Instead, we can use Promises to regulate the order in which our scripts are loaded:
 
-{% include codeHeader.html file: "loadScript.js" %}
-```javascript
+```javascript {data-file="loadScript.js" data-copyable=true}
 function loadScript(url) {
   const script = document.createElement('script');
   document.body.appendChild(script);
@@ -305,8 +297,7 @@ function loadScript(url) {
 
 Now, all we need to do is chain Promises:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 loadScript('two.js')
   .then(() => loadScript('one.js'))
   .then(() => loadScript('three.js'))
@@ -327,8 +318,7 @@ Note that there are very few situations in the real world where you'd actually n
 
 The Chrome extension API allows you to save and read user preferences. The read operation is performed asynchronously, so you need to pass in a callback for when the data becomes ready:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 chrome.storage.sync.get({ 'foo' }, setting => {
     if (chrome.runtime.lastError) {
         throw new Error(`Failed to read setting.`);
@@ -342,8 +332,7 @@ That works, but you'll soon grow tired of passing in a callback every single tim
 
 We can easily convert this to a Promise-based syntax. We'll create a utility function named `readSetting` that abstracts away the callback and either resolves with the value of the setting or rejects if the Chrome runtime encounters an error:
 
-{% include codeHeader.html file: "readSetting.js" %}
-```javascript
+```javascript {data-file="readSetting.js" data-copyable=true}
 export default function readSetting(settingName) {
   return new Promise((resolve, reject) => {
     chrome.storage.sync.get(
@@ -362,8 +351,7 @@ export default function readSetting(settingName) {
 
 And now we can use either `async`/`await` or `then` to read settings in a much more legible manner:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const bar = await readSetting('foo');
 ```
 
@@ -375,8 +363,7 @@ Normally, an [operating system's scheduler](/blog/operating-system-scheduling-al
 
 Why would you want to do this? Sleeping is useful if you want to regulate **the rate at which code is executed**. And just to be clear, you can definitely do this in vanilla JavaScript without Promises:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 for (let i = 1; i <= 10; i++) {
     setTimeout(() => console.log(i), i * 1000);
 }
@@ -388,8 +375,7 @@ for (let i = 1; i <= 10; i++) {
 
 This works, but it's a little difficult to understand compared to the following C++ code:
 
-{% include codeHeader.html %}
-```cpp
+```cpp {data-copyable=true}
 #include <chrono>
 #include <thread>
 
@@ -405,8 +391,7 @@ for (int i = 1; i <= 10; i++) {
 
 Fortunately, we can achieve something similar using a Promise that resolves after `ms` time elapses:
 
-{% include codeHeader.html file: "utils/sleep.js" %}
-```javascript
+```javascript {data-file="utils/sleep.js" data-copyable=true}
 export default function sleep(ms) {
     return new Promise(resolve => {
         setTimeout(resolve, ms);
@@ -416,8 +401,7 @@ export default function sleep(ms) {
 
 Now, with ES7's `async`/`await`, we can write the following:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 import sleep from 'utils/sleep';
 
 for (let i = 1; i <= 10; i++) {

--- a/src/_posts/2020-09-21-css-aspect-ratio.md
+++ b/src/_posts/2020-09-21-css-aspect-ratio.md
@@ -107,8 +107,7 @@ Let's say you want to embed a YouTube video on your page, and you know that [You
 
 For both code samples, we'll work with this common markup:
 
-{% include codeHeader.html file: "youtube-iframe.html" %}
-```html
+```html {data-file="youtube-iframe.html" data-copyable=true}
 <iframe src="..." class="youtube-iframe"></iframe>
 ```
 
@@ -116,8 +115,7 @@ For both code samples, we'll work with this common markup:
 
 With CSS's `aspect-ratio` property, we can style the iframe directly:
 
-{% include codeHeader.html file: "youtube-iframe.css" %}
-```css
+```css {data-file="youtube-iframe.css" data-copyable=true}
 .youtube-iframe {
   aspect-ratio: 16 / 9;
 }
@@ -129,8 +127,7 @@ That's it! As we'll see in the remaining examples, this new property makes it tr
 
 We can achieve the same result using the padding trick that we learned. It requires a bit more work and some additional markup. We'll need two elements: an aspect ratio box for the parent container (e.g., a `<div>`), and the iframe itself nested as a child:
 
-{% include codeHeader.html file: "youtube-iframe.html" %}
-```html
+```html {data-file="youtube-iframe.html" data-copyable=true}
 <div class="embed-container">
   <iframe class="youtube-iframe">...</iframe>
 </div>
@@ -140,8 +137,7 @@ To create an aspect ratio box with `16:9`, we set the box's height to be zero an
 
 The final step is to relatively position the container and absolutely position the iframe so that it doesn't influence the container's height. And here's the CSS that'll do that for us:
 
-{% include codeHeader.html file: "youtube-iframe.css" %}
-```css
+```css {data-file="youtube-iframe.css" data-copyable=true}
 .embed-container {
   position: relative;
   height: 0;
@@ -164,8 +160,7 @@ That's it! Your YouTube iframe will now maintain a `16:9` aspect ratio on all de
 
 With our knowledge of how to create aspect ratios in CSS, we can easily create a [3x3 square layout](https://tobiasahlin.com/blog/common-flexbox-patterns/#3x3-grid-constrained-proportions-11) with either Flexbox or CSS Grid. We'll work with this common markup and CSS:
 
-{% include codeHeader.html file: "grid.html" %}
-```html
+```html {data-file="grid.html" data-copyable=true}
 <ul class="square-grid">
   <li class="square"></li>
   <li class="square"></li>
@@ -179,8 +174,7 @@ With our knowledge of how to create aspect ratios in CSS, we can easily create a
 </ul>
 ```
 
-{% include codeHeader.html file: "grid.css" %}
-```css
+```css {data-file="grid.css" data-copyable=true}
 .square-grid {
   width: 100%;
   display: grid;
@@ -207,8 +201,7 @@ Once again, we can take one of two approaches, depending on which browsers we ne
 
 To make each grid item a square, we just have to give them an aspect ratio of `1/1`:
 
-{% include codeHeader.html file: "grid.css" %}
-```css
+```css {data-file="grid.css" data-copyable=true}
 .square {
   aspect-ratio: 1 / 1;
 }
@@ -220,8 +213,7 @@ This says that the grid item's width and height should always be the same.
 
 With the percentage padding trick, we once again zero out the element's height. This time, we give it a vertical padding of `100%`, which means that its height is always the same as its width:
 
-{% include codeHeader.html file: "grid.css" %}
-```css
+```css {data-file="grid.css" data-copyable=true}
 .square {
   height: 0;
   padding-bottom: 100%;
@@ -252,8 +244,7 @@ Regardless of which approach you take, you'll get a `3x3` grid of images that ar
 
 As before, we'll style the squares to have a `1:1` aspect ratio. But we'll also want to set the width and height of the nested images to be `100%`. Finally, we'll use `object-fit` and `object-position` to ensure that overflowing images are cropped and centered:
 
-{% include codeHeader.html file: "image-grid.css" %}
-```css
+```css {data-file="image-grid.css" data-copyable=true}
 .square {
   aspect-ratio: 1 / 1;
 }
@@ -272,8 +263,7 @@ Notice that we don't have to mess with absolute positioning or zero-out the `.sq
 
 With the percentage padding trick, the CSS for the grid is the same. But we need to absolutely position the images so that they don't influence each `.square`'s height. And, as before, we also need to use `object-fit` and `object-position` so that overflowing images are cropped.
 
-{% include codeHeader.html file: "image-grid.css" %}
-```css
+```css {data-file="image-grid.css" data-copyable=true}
 .square {
   height: 0;
   padding-bottom: 100%;
@@ -406,8 +396,7 @@ Here, **inline size** is defined as follows:
 
 To verify this, we can set up a mini sandbox document with a single parent and child element:
 
-{% include codeHeader.html file: "test.html" %}
-```html
+```html {data-file="test.html" data-copyable=true}
 <div class="parent">
   <div class="child">
     Child
@@ -417,8 +406,7 @@ To verify this, we can set up a mini sandbox document with a single parent and c
 
 And style it like this:
 
-{% include codeHeader.html file: "test.css" %}
-```css
+```css {data-file="test.css" data-copyable=true}
 body {
   writing-mode: vertical-rl;
   width: 100%;

--- a/src/_posts/2020-10-11-undoing-changes-in-git.md
+++ b/src/_posts/2020-10-11-undoing-changes-in-git.md
@@ -15,8 +15,7 @@ Eventually, there will come a point when you'll find yourself having to modify o
 
 Before we get to the examples, let's create a simple git repo with a few commits:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git init && \
 echo {} > package.json && git add . && git commit -m "Add package.json" && \
 echo FOO=bar > .env && git add . && git commit -m "Add .env" && \
@@ -66,8 +65,7 @@ You have this commit history:
 
 Shortly after creating your `.gitignore` and committing it, you decide to change the file:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 echo node_modules > .gitignore
 ```
 
@@ -75,8 +73,7 @@ But you don't want to pollute your git log history with yet another commit for s
 
 Both of these are classic use cases for the `git amend` command:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git commit -a --amend
 ```
 
@@ -102,8 +99,7 @@ Save and close the file, and git will amend the most recent commit to include yo
 
 If all you need to do is update the commit message itself, like to fix a typo, you don't actually need to stage any changes. All you need to do is run this command:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git commit --amend
 ```
 
@@ -148,8 +144,7 @@ As a reminder, we have this commit history so far:
 
 Let's add one more commit directly to `master`:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 touch file && git add . && git commit -m "Add a file"
 ```
 
@@ -165,8 +160,7 @@ So now we have this commit history:
 
 A few minutes later, for one reason or another, you decide that you don't actually want to keep the most recent commit. To delete it, you can just do a hard reset to one commit before the `HEAD` pointer, which is always pointing to the latest commit on the current branch:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard HEAD~1
 ```
 
@@ -182,15 +176,13 @@ Hard resetting is a handy way to undo changes in git, but do note that this is a
 
 You can also reset to the `HEAD~n`th commit, in which case all work *at and after that commit* will be lost:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard HEAD~4
 ```
 
 Or even to a specific commit, if you have its hash:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard <hash-id>
 ```
 
@@ -198,15 +190,13 @@ You're also not limited to just resetting against commits in the current branch.
 
 For example, you can reset a local branch to point to another local branch:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git reset --hard <someOtherBranch>
 ```
 
 Or even to a remote branch:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard origin/master
 ```
 
@@ -216,22 +206,19 @@ Sure, you can use `git cherry-pick` to fix this, but what if you have tens or hu
 
 To fix this, you'd create the feature branch now (off of `master`, which has the commits you want):
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout -b feat/X
 ```
 
 And forcibly reset your local `master` branch to your remote `master`:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout master && git reset --hard origin/master
 ```
 
 And don't forget to go back to your feature branch so you don't repeat the same mistake:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout feat/X
 ```
 
@@ -239,15 +226,13 @@ git checkout feat/X
 
 As I mentioned above, if you do a hard reset, you'll lose any work that you did at or past that commit. You can recover from that state, sure, but that's one extra step. If instead you want to keep your changes in git's staging environment, you can do a soft reset:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --soft HEAD~1
 ```
 
 And again, you can just use a commit hash instead of backtracking from the `HEAD` pointer:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --soft a80951b
 ```
 
@@ -259,8 +244,7 @@ All of the changes introduced by that commit, and any commits that came after it
 
 You're probably already comfortable with branching for new iterations of work. But don't forget that you can also use branching as a backup mechanism, in case you know you're about to run a command (like `git reset --hard`) that may mess up your branch's commit history. Before you run those commands, you can simply create a temporary backup branch (e.g., `git branch backup`). If anything goes wrong, you can always do a hard reset against your backup branch:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard backup
 ```
 
@@ -287,8 +271,7 @@ So far, we have this commit history:
 
 That second commit looks a little suspicious... Why did we check our local environment variables (`.env`) into git? Oops. Clearly, we need to delete this commit while keeping all of the others around. To do that, we'll run an interactive rebase against that commit:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase -ir 2beb7c7^
 ```
 
@@ -324,8 +307,7 @@ And now, if you do a `git log`, you'll no longer see that commit:
 
 Note that any commit hashes after the deleted commit will be recomputed. So while the root commit remains untouched as `0beebfb`, all hashes after it changed. As we've seen a few times now, if you had pushed this branch to your repo earlier, the local and remote branches will now be out of sync. So you'll just need to do a force push to update the remote branch:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git push -f
 ```
 
@@ -345,8 +327,7 @@ Looking back at this, we'll want to reword those last two commit message since, 
 
 As usual, we'll start with an interactive rebase. Here, we'll target the last two commits:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase -i HEAD~2
 ```
 
@@ -445,15 +426,13 @@ So far, our commit history looks like this:
 
 Let's say we want to edit the root commit (`0beebfb`) and add a second file:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 touch .yarnrc
 ```
 
 We'll start an interactive rebase against that commit. In this special case of editing the root commit, we'll need to use the `--root` option:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase -i --root
 ```
 
@@ -492,8 +471,7 @@ Once you are satisfied with your changes, run
 
 Neat! We'll now run these two commands:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git add .yarnrc && git commit --amend
 ```
 
@@ -526,8 +504,7 @@ Add package.json
 
 Let's change that message to be `Initialize npm package` and save and exit. Now, per git's suggestion, we need to continue with the rebase:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase --continue
 ```
 
@@ -557,8 +534,7 @@ Again, for reference, we have this commit history:
 
 Let's create a toy feature branch and add some commits:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout -b feature && \
 touch file1 && git add . && git commit -m "Add file1" && \
 touch file2 && git add . && git commit -m "Add file2" && \
@@ -580,8 +556,7 @@ New commit history:
 
 Assuming our pull request has been reviewed, we can squash all of these into one with the following command:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase -i master
 ```
 
@@ -593,8 +568,7 @@ This rebases our feature branch against the `master` branch. Note that `master` 
 
 So this is really the same as doing:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git rebase -i 436e421
 ```
 
@@ -683,8 +657,7 @@ Yikes.
 
 That's precisely why `git revert` exists. Unlike deleting commits via rebases or hard/soft resets, the revert command creates a new commit to undo any changes introduced by the target commit:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git revert <hash-id>
 ```
 
@@ -700,8 +673,7 @@ Let's say we're on our `master` branch and want to revert the commit with a hash
 
 To do that, we'd run:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git revert beb7c13
 ```
 
@@ -750,8 +722,7 @@ We'll focus on the third use case here.
 
 If you have unstaged changes to local files, you can easily undo those changes using the checkout command:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout <pathspec>
 ```
 
@@ -761,15 +732,13 @@ This will clear all unstaged changes to the specified files and restore the curr
 
 For example, if you want to clear *all* unstaged changes in the current directory and start from scratch, the easy way to do that is using the `git checkout` command with `.` as the pathspec:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout .
 ```
 
 You can also use `git checkout` to restore local or remote versions of a file. For example, you can check out your remote master's copy of a file:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout origin/master -- <pathspec>
 ```
 
@@ -777,8 +746,7 @@ Let's say you need to undo your local changes to a particular file, but those ch
 
 Similarly, you can check out another local branch's copy of a file:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout localBranchName -- <pathspec>
 ```
 
@@ -796,15 +764,13 @@ Put differently, reflog captures a series of snapshots for the different states 
 
 Viewing the reflog for a git repository couldn't be easier:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reflog
 ```
 
 For example, if I'm on my `feature` branch, I can check out a new branch and git will log that activity:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout -b feature2
 ```
 
@@ -861,15 +827,13 @@ This tells the story of your entire repo, showing all of the different commits t
 
 You can quickly peek at any of these states by checking out those commit hashes:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git checkout <hash-id>
 ```
 
 Or, better yet, you can **reset your branch to those points in history**. Check it out:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --soft 7598875
 ```
 
@@ -890,8 +854,7 @@ And I can even run another `reflog` to see *that* change!
 
 And, if *that* was undesirable, you can run *yet another* `reflog` and reset to the `HEAD` right before you took that action:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reset --hard b646cf6
 ```
 
@@ -910,8 +873,7 @@ Git's `reflog` command is useful in case you ever do a hard reset and lose all o
 
 Finally, if for whatever reason you want to clean up your `reflog`, you can delete lines from it using:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 git reflog delete HEAD@{n}
 ```
 

--- a/src/_posts/2020-10-18-higher-order-components.md
+++ b/src/_posts/2020-10-18-higher-order-components.md
@@ -73,8 +73,7 @@ Suppose we're using React to create a blog (e.g., with a static site generator l
 
 To kick things off, we'll create a basic presentational component named `PostList` that represents a generic list of posts. Nothing fancy here:
 
-{% include codeHeader.html file: "components/PostList/index.js" %}
-```jsx
+```jsx {data-file="components/PostList/index.js" data-copyable=true}
 import React from "react";
 
 const PostList = ({ posts }) => (
@@ -93,8 +92,7 @@ export default PostList;
 
 Your blog is going to have three different kinds of posts: recent, popular, and archived. Since we don't actually have any real data to work with here, we'll create some fake data and use that for this tutorial:
 
-{% include codeHeader.html file: "containers/Posts/api.js" %}
-```js
+```js {data-file="containers/Posts/api.js" data-copyable=true}
 const recentPosts = [
   {
     id: 1,
@@ -167,8 +165,7 @@ In the real world, you'd hit an actual API endpoint rather than returning local,
 
 Our blog will consist of the following container component:
 
-{% include codeHeader.html file: "containers/Posts/index.js" %}
-```jsx
+```jsx {data-file="containers/Posts/index.js" data-copyable=true}
 import React from "react";
 import {
   ArchivedPosts,
@@ -200,8 +197,7 @@ export default Posts;
 
 Of course, the three components you see here don't exist just yet, so let's go ahead and create them now. We'll use the fetch functions we defined just a few seconds ago to do that. Keep in mind that in the real world, you'd probably use some Promise-based fetch function to get your data, and thus you'd need to either `await` your data or chain `then`s:
 
-{% include codeHeader.html file: "components/PostList/index.js" %}
-```jsx
+```jsx {data-file="components/PostList/index.js" data-copyable=true}
 import React, { useEffect, useState } from "react";
 import {
   getArchivedPosts,
@@ -270,8 +266,7 @@ That's precisely the idea behind higher-order components in React.
 
 I'll show the higher-order component for this scenario now, in its entirety, and then explain how it works:
 
-{% include codeHeader.html file: "components/PostList/withPosts.js" %}
-```jsx
+```jsx {data-file="components/PostList/withPosts.js" data-copyable=true}
 import React, { useState, useEffect } from "react";
 
 function withPosts(Component, getPosts) {
@@ -311,8 +306,7 @@ function withPosts(Component, getPosts) {
 
 In fact, if we had wanted to, we could've used the legacy React syntax and returned a class instead, to make it perfectly clear that a higher-order component returns a React component:
 
-{% include codeHeader.html file: "components/PostList/withPosts.js" %}
-```jsx
+```jsx {data-file="components/PostList/withPosts.js" data-copyable=true}
 import React, { useState, useEffect } from "react";
 
 function withPosts(Component, getPosts) {
@@ -344,8 +338,7 @@ In both versions of the code, the inner component accepts props (just like all R
 
 Now, using this higher-order component couldn't be easier:
 
-{% include codeHeader.html file: "components/PostList/index.js" %}
-```jsx
+```jsx {data-file="components/PostList/index.js" data-copyable=true}
 export const RecentPosts = withPosts(PostList, getRecentPosts);
 export const PopularPosts = withPosts(PostList, getPopularPosts);
 export const ArchivedPosts = withPosts(PostList, getArchivedPosts);
@@ -358,8 +351,7 @@ Notice that we're calling the higher-order component three times here, once for 
 
 Since the result of a call to a higher-order component is just another component, these exported variables can be rendered. Thus, the code from earlier should make sense:
 
-{% include codeHeader.html file: "containers/Posts/Posts.js" %}
-```jsx
+```jsx {data-file="containers/Posts/Posts.js" data-copyable=true}
 import React from "react";
 import {
   ArchivedPosts,
@@ -391,8 +383,7 @@ export default Posts;
 
 Additionally, if we had wanted to, we could've also passed along more props to these components:
 
-{% include codeHeader.html file: "containers/Posts/Posts.js" %}
-```jsx
+```jsx {data-file="containers/Posts/Posts.js" data-copyable=true}
 import React from "react";
 import {
   RecentPosts,
@@ -442,8 +433,7 @@ One last thing worth noting with this example: You may be wondering why we didn'
 
 In other words, why not do this:
 
-{% include codeHeader.html file: "components/PostList/withPosts.js" %}
-```jsx
+```jsx {data-file="components/PostList/withPosts.js" data-copyable=true}
 import React, { useState, useEffect } from "react";
 import PostList from "./PostList";
 
@@ -464,8 +454,7 @@ export default withPosts;
 
 That would certainly save us some typing here, as we'd no longer have to specify `PostList` as the first argument to each function call:
 
-{% include codeHeader.html file: "components/PostList/index.js" %}
-```jsx
+```jsx {data-file="components/PostList/index.js" data-copyable=true}
 export const RecentPosts = withPosts(getRecentPosts);
 export const PopularPosts = withPosts(getPopularPosts);
 export const ArchivedPosts = withPosts(getArchivedPosts);
@@ -481,8 +470,7 @@ If you're with me so far, you may have noticed an interesting fact: Higher-order
 
 Consider this toy example:
 
-{% include codeHeader.html %}
-```jsx
+```jsx {data-copyable=true}
 const Div = (props) => <div {...props} />;
 
 function withX(Component) {
@@ -666,8 +654,7 @@ export default withTheme(MyComponent);
 
 Check it out—here's the code for the `ThemeToggle` button:
 
-{% include codeHeader.html file: "ThemeToggle/index.js", copyable: false %}
-```jsx
+```jsx {data-file="ThemeToggle/index.js"}
 import React from "react";
 import { themeMap, withTheme } from "../App";
 
@@ -699,8 +686,7 @@ One question that comes up often is whether higher-order components are relevant
 
 Returning to our blog example, we could instead create a reusable `usePosts` hook to consolidate the fetching logic and return the list of posts and a method to optionally update those posts:
 
-{% include codeHeader.html file: "components/PostList/usePosts.js" %}
-```jsx
+```jsx {data-file="components/PostList/usePosts.js" data-copyable=true}
 import React, { useState, useEffect } from "react";
 
 export default function usePosts(getPosts) {
@@ -717,8 +703,7 @@ export default function usePosts(getPosts) {
 
 And here's how we might use that:
 
-{% include codeHeader.html file: "components/PostList/index.js" %}
-```jsx
+```jsx {data-file="components/PostList/index.js" data-copyable=true}
 import React from "react";
 import usePosts from "./usePosts";
 import {

--- a/src/_posts/2020-11-01-dynamic-tag-name-props-in-react.md
+++ b/src/_posts/2020-11-01-dynamic-tag-name-props-in-react.md
@@ -19,8 +19,7 @@ Layout components are a good real-world use case for this—they might apply som
 
 To keep this tutorial simple, I'll create a pointless demo component:
 
-{% include codeHeader.html file: "components/Component/index.tsx" %}
-```tsx
+```tsx {data-file="components/Component/index.tsx" data-copyable=true}
 import { FC } from 'react';
 interface ComponentProps {}
 const Component: FC<ComponentProps> = (props) => <div {...props} />;
@@ -30,8 +29,7 @@ You *could* always render a `div`, but that's inflexible—it may work well for 
 
 To fix this, you can use the [`ElementType` type](https://flow.org/en/docs/react/types/#toc-react-elementtype) to allow passing in a tag name as a prop:
 
-{% include codeHeader.html file: "components/Component/index.tsx" %}
-```tsx
+```tsx {data-file="components/Component/index.tsx" data-copyable=true}
 import { ElementType, HTMLAttributes, FC } from 'react';
 
 interface ComponentProps extends HTMLAttributes<HTMLOrSVGElement> {
@@ -53,8 +51,7 @@ First, [React expects component names to be capitalized](https://reactjs.org/doc
 
 Second, our component renders a `div` by default. We do this with destructuring and default assignment in the component's signature. But you can override this behavior by passing in a custom tag name on an as-needed basis:
 
-{% include codeHeader.html file: "components/Navbar/index.tsx" %}
-```tsx
+```tsx {data-file="components/Navbar/index.tsx" data-copyable=true}
 import Component from 'components/Component';
 import { FC } from 'react';
 

--- a/src/_posts/2020-11-25-async-functions-that-return-booleans.md
+++ b/src/_posts/2020-11-25-async-functions-that-return-booleans.md
@@ -8,8 +8,7 @@ thumbnail: thumbnail.png
 
 Here's a fun bug I recently encountered... Let's say we have this `async` JavaScript function:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const isBroken = async () => {
   return false;
 }
@@ -54,8 +53,7 @@ Promise {<fulfilled>: false}
 
 Our async function's return value is not `false` itself but rather a Promise object that *resolved* with the value `false`. In other words, it's the same as doing this:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const isBroken = () => {
   return Promise.resolve(false);
 }
@@ -69,8 +67,7 @@ Spot the problem? This is an issue of **truthiness**: a `Promise` object is not 
 
 For the code above to work as intended, you'll need to `await` the result in another `async` function (or, equivalently, chain a `.then` call on the returned Promise object):
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const isBroken = async () => {
   return false;
 }

--- a/src/_posts/2021-01-07-vertical-rhythm-with-css-grid.md
+++ b/src/_posts/2021-01-07-vertical-rhythm-with-css-grid.md
@@ -15,8 +15,7 @@ Margins are the gold standard for spacing paragraphs, images, and block-level el
 
 Suppose we have this markup for an article:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <article id="post">
   <h1>My Awesome Post Title</h1>
   <p>
@@ -37,8 +36,7 @@ Suppose we have this markup for an article:
 
 Nice and simple. Now, let's apply a line height to our body and some margins to those paragraphs to establish a vertical rhythm. Note that the choice of font size and line height is entirely dependent on the font. I recommend picking a `line-height` that gives you some multiple of your base spacing unit (I prefer to use a `4px` [linear scale](https://www.designsystems.com/space-grids-and-layouts/)). In this particular example, I'll go with a font size of `1.125rem = 18px` and a `line-height` of `1.33 = 24px`.
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 body {
   font-size: 1.125rem;
   line-height: 1.33;
@@ -61,8 +59,7 @@ That's all well and good:
 
 But a few minutes later, you decide to spice things up with some headings and maybe an image.
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <article id="post">
   <h1>My Awesome Post Title</h1>
   <p>
@@ -89,8 +86,7 @@ And that gives us this:
 
 The image doesn't have any bottom margin, and neither does the subheading. Let's fix that!
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 #post img {
   display: block;
 }

--- a/src/_posts/2021-01-18-svg-tutorial-how-to-code-svg-icons-by-hand.md
+++ b/src/_posts/2021-01-18-svg-tutorial-how-to-code-svg-icons-by-hand.md
@@ -322,8 +322,7 @@ As a reminder, an SVG's coordinate system starts with `(0, 0)` at the top-left c
 
 SVGs allow us to specify the starting and ending points for lines using four attributes: `x1`, `y1`, `x2`, and `y2`. So, to draw a simple horizontal line, we could do the following:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <line x1="0" y1="4.2" x2="24" y2="4.2"/>
 </svg>
@@ -357,8 +356,7 @@ With the stroke color set, we can finally view our line:
 
 When you scale this down, that line may actually look a bit thin. That's because it's using a default stroke width of `1` unit. Fortunately, we can change its thickness with the `stroke-width` attribute, either on the parent SVG element or any individual shape. If you set it on the SVG parent, all shapes will inherit that value. Like with the stroke color, though, you can also do this via a CSS property of the same name, like this:
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 svg {
   stroke-width: 2;
 }
@@ -376,8 +374,7 @@ I'll use a stroke width of `2` for the rest of this tutorial. You can pick a dif
 
 And that's all we need to know to draw the three icons we saw earlier! We'll just tweak the `x` coordinates to get shorter or longer lines, as needed. Here's the full markup for all three icons:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <line x1="2" y1="4.2" x2="22" y2="4.2"/>
   <line x1="2" y1="9.4" x2="16" y2="9.4"/>
@@ -404,8 +401,7 @@ We have four lines, each with a stroke width of `2`; together, they occupy a tot
 
 By the way, you may find it useful to temporarily give your SVG elements a border as you're drawing them so you can better visualize the constraints you're working with:
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 svg {
   border: 1px solid;
 }
@@ -442,8 +438,7 @@ I'll do that for most demonstrations in this tutorial.
 
 Before we move on, note that you don't have to draw lines that are perfectly horizontal. You can also draw perfectly vertical lines:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <line x1="12" y1="2" x2="12" y2="22" />
 </svg>
@@ -457,8 +452,7 @@ Before we move on, note that you don't have to draw lines that are perfectly hor
 
 Or even diagonal lines:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <line x1="2" y1="2" x2="22" y2="22" />
 </svg>
@@ -492,8 +486,7 @@ Fortunately for us, that's why `<polyline>` exists! It basically lets us define 
 
 A `<polyline>` is defined with the help of the `points` attribute, like this:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 4, 21 4" />
 </svg>
@@ -519,8 +512,7 @@ Anyway, your browser draws a solid line between the first pair of coordinates, a
 
 We can draw the text icon I showed earlier by combining `<polyline>` and a basic `<line>` shape. We'll start by creating the top-left serif of the letter `T`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 8, 3 4" />
 </svg>
@@ -534,8 +526,7 @@ We can draw the text icon I showed earlier by combining `<polyline>` and a basic
 
 From `(3, 4)`, we'll travel horizontally until we're an equal distance from the right edge as we were from the left:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 8, 3 4, 21 4" />
 </svg>
@@ -553,8 +544,7 @@ This is because of an SVG property that I hid from you until now: `fill`. Just l
 
 Note that certain icons may actually benefit from having a custom fill, so you wouldn't want to *always* disable this globally in your app. But for our purposes, it's going to get in the way of drawing shapes like polylines, polygons, etc. since we don't actually *need* a fill. So, for the rest of this tutorial, I'll use this additional CSS to clear the fill for all icons:
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 svg {
   fill: none;
 }
@@ -570,8 +560,7 @@ With that set, our shape should look correct now:
 
 Now, we'll drop down vertically again to complete the right serif of the letter `T`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 8, 3 4, 21 4, 21 8" />
 </svg>
@@ -585,8 +574,7 @@ Now, we'll drop down vertically again to complete the right serif of the letter 
 
 From here, we just need to complete the stem and base of the letter:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 8, 3 4, 21 4, 21 8" />
   <line x1="12" y1="4" x2="12" y2="20" />
@@ -604,8 +592,7 @@ From here, we just need to complete the stem and base of the letter:
 
 Note that you could just as well use polylines for the two lines; you'll get the same shape:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polyline points="3 8, 3 4, 21 4, 21 8" />
   <polyline points="12 4, 12 20" />
@@ -646,8 +633,7 @@ This is because of two related SVG attributes (and their equivalent CSS properti
 
 For the remainder of this tutorial, all examples will use the following CSS:
 
-{% include codeHeader.html %}
-```css
+```css {data-copyable=true}
 svg {
   stroke-linejoin: round;
   stroke-linecap: round;
@@ -698,8 +684,7 @@ In geometry class, you probably learned that in order to draw a circle, you need
 
 Well, it's exactly the same with SVGs! Here's the markup for a simple circle:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
 </svg>
@@ -750,8 +735,7 @@ Now that we know how to draw circles in SVG, we can draw the three icons shown e
 
 We'll start with the face of the clock as a circle:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
 </svg>
@@ -765,8 +749,7 @@ We'll start with the face of the clock as a circle:
 
 The only thing left is to draw the clock hands, and for that we'll use a polyline:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
   <polyline points="13 7, 13 14, 9 14" />
@@ -786,8 +769,7 @@ One down, two to go!
 
 Just as before, we'll first create the circle:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
 </svg>
@@ -801,8 +783,7 @@ Just as before, we'll first create the circle:
 
 The rest of the info icon consists of a line and a circle. Here's the body of the `i`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
   <line x1="12" y1="12" x2="12" y2="16" />
@@ -818,8 +799,7 @@ The rest of the info icon consists of a line and a circle. Here's the body of th
 
 And here's the dot in the `i`; we give it a fill so it's solid:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <circle cx="12" cy="12" r="10" />
   <circle cx="12" cy="8" r="0.5" fill="currentColor" />
@@ -841,8 +821,7 @@ Observe that the radius is `0.5` because the circle is filled, and we don't want
 
 Last one! For this icon, I'll just give you the full markup; it's a circle, a line, and a polyline:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64" class="bordered">
   <circle cx="12" cy="12" r="10" />
   <line x1="8" y1="12" x2="16" y2="12" />
@@ -866,8 +845,7 @@ Remember how I mentioned that `<polyline>`s are not self-closing? Well, the natu
 
 For example, `<polygon>` allows us to draw a triangle using just three points:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polygon points="12 2, 22 22, 2 22" />
 </svg>
@@ -881,8 +859,7 @@ For example, `<polygon>` allows us to draw a triangle using just three points:
 
 Cool! Building on this, we can now create the warning indicator icon that I showed you at the start of this tutorial. This should be familiar if you recall how we created the info icon before:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polygon points="12 2, 22 22, 2 22" />
   <line x1="12" y1="10" x2="12" y2="14" />
@@ -900,8 +877,7 @@ Cool! Building on this, we can now create the warning indicator icon that I show
 
 By the way, I mentioned above that we can use `<polygon>` to create all kinds of shapes, but some come as pre-built shapes. For example, rectangles *can* be created with `<polygon>`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <polygon points="2 4, 22 4, 22 22, 2 22" />
 </svg>
@@ -915,8 +891,7 @@ By the way, I mentioned above that we can use `<polygon>` to create all kinds of
 
 But they can also be created with `<rect>`, which takes an `x` and a `y` coordinate for its top-left corner along with a `width` and `height`. This is all that's needed to draw a rectangle:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <rect x="4" y="4" width="18" height="18" />
 </svg>
@@ -930,8 +905,7 @@ But they can also be created with `<rect>`, which takes an `x` and a `y` coordin
 
 While we're here, why don't we draw a calendar icon? That one is technically created using a `<path>`, which we'll learn about in the very next section. For now, we can use a `<rect>` and see how that looks.
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
   <svg viewBox="0 0 24 24" width="64" height="64">
     <rect x="3" y="5" width="18" height="16" />
     <line x1="4" y1="10" x2="20" y2="10" />
@@ -1038,8 +1012,7 @@ This is easier to remember than it looks: `M` for **m**oving, `H/h` for **h**ori
 
 If you're with me so far, then you should understand the first two commands in this path:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1077,8 +1050,7 @@ To help this sink in, let's also make a pause icon with two parallel vertical li
 
 Here's the code that does that:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1099,8 +1071,7 @@ Let's interpret these commands one at a time:
 
 Notice how we mixed relative and absolute commands. We could've also said this:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1132,8 +1103,7 @@ Finally, note that `L/l` is the more generic version of `H/h` and `V/v`. Whereas
 
 Here's an example of drawing a diagonal line with a relative `LineTo` command:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1163,8 +1133,7 @@ The command `Z` (or `z`) stands for `ClosePath`. Remember when we learned about 
 
 For example, to draw a self-closing square with `<path>`, we only need to draw three of the four lines explicitly; the fourth can be drawn automatically for us with the `ClosePath` command:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1279,8 +1248,7 @@ The `large-arc-flag` and `sweep-flag` parameters are probably the more confusing
 
 As before, it helps to look at a concrete example. Here's a very simple arc in Quadrant 1:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1304,8 +1272,7 @@ This yields a counter-clockwise arc because we've set `sweep-flag` to be `0`:
 
 And, as you may have guessed, we can chain four arcs to create a circle:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1341,8 +1308,7 @@ I'll take this one step at a time so you can visualize the process.
 
 First, we'll draw the top portion of the calendar (you could start elsewhere, though):
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1364,8 +1330,7 @@ First, we'll draw the top portion of the calendar (you could start elsewhere, th
 
 Then, we draw a `2x2` clockwise arc, moving `2px` to the right and `2px` down:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1389,8 +1354,7 @@ Then, we draw a `2x2` clockwise arc, moving `2px` to the right and `2px` down:
 
 From there, we go down `14px`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1416,8 +1380,7 @@ From there, we go down `14px`:
 
 Draw the bottom-right corner's arc:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1445,8 +1408,7 @@ Draw the bottom-right corner's arc:
 
 Move left by `16px`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1476,8 +1438,7 @@ Move left by `16px`:
 
 Draw the arc for the bottom-left corner:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1509,8 +1470,7 @@ Draw the arc for the bottom-left corner:
 
 Move up `14px`:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1544,8 +1504,7 @@ Move up `14px`:
 
 And finally, close off the shape with an explicit arc rather than `z` (which will draw a line).
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1581,8 +1540,7 @@ And finally, close off the shape with an explicit arc rather than `z` (which wil
 
 And that's all there is to the rounded rectangle bit! Now, we just throw on a few lines:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="
@@ -1630,8 +1588,7 @@ We're almost done!
 
 Hopefully, you're now comfortable enough with SVG paths to interpret the code here:
 
-{% include codeHeader.html %}
-```html
+```html {data-copyable=true}
 <svg viewBox="0 0 24 24" width="64" height="64">
   <path
     d="M 18 14

--- a/src/_posts/2021-04-18-crlf-vs-lf-normalizing-line-endings-in-git.md
+++ b/src/_posts/2021-04-18-crlf-vs-lf-normalizing-line-endings-in-git.md
@@ -106,8 +106,7 @@ git config --global core.autocrlf [true|false|input]
 
 You can also view the current Git setting using this command:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git config --list
 ```
 
@@ -151,8 +150,7 @@ Fortunately, there's a better solution: creating a `.gitattributes` file at the 
 
 The following `.gitattributes` config normalizes line endings to `LF` for all text files checked into Git's index while leaving local line endings untouched:
 
-{% include codeHeader.html file: ".gitattributes" %}
-```bash
+```bash {data-file=".gitattributes" data-copyable=true}
 * text=auto
 ```
 
@@ -166,15 +164,13 @@ More specifically, [the `text=auto` option](https://git-scm.com/docs/gitattribut
 
 After committing the `.gitattributes` file, your changes won't take effect immediately for files checked into Git *prior* to the addition of `.gitattributes`. To force an update, you can use the following command [since Git 2.16](https://stackoverflow.com/a/50645024/5323344):
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git add --renormalize .
 ```
 
 This updates all files in Git's index according to the rules defined in your `.gitattributes` config. If previously committed text files used `CRLF` in Git's index and are converted to `LF` during the renormalization process, those files will be staged for a commit. You can then check if any files were modified like you would normally:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git status
 ```
 
@@ -184,8 +180,7 @@ The only thing left to do is to commit those changes (if any) and push them to y
 
 If you want to verify that the files in Git's index are using the correct line endings after all of these steps, you can run the following command:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git ls-files --eol
 ```
 
@@ -238,8 +233,7 @@ When we [configured our local Git settings](#configuring-line-endings-in-git-wit
 
 In the case of batch scripts, we'd use `eol=crlf`:
 
-{% include codeHeader.html file: ".gitattributes" %}
-```bash
+```bash {data-file=".gitattributes" data-copyable=true}
 # All files are checked into Git's index with LF
 * text=auto
 
@@ -251,8 +245,7 @@ In this case, batch scripts will have two non-overlapping rules applied to them 
 
 **This change won't take effect immediately**, so if you run `git ls-files --eol` after updating your `.gitattributes` file, you might still see `LF` line endings in the working tree. To update existing line endings in your working tree so they respect the `eol` attribute, you'll need to run the following set of commands [per this StackOverflow answer](https://stackoverflow.com/a/29888735/5323344):
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 git rm --cached -r .
 git reset --hard
 ```
@@ -308,8 +301,7 @@ Again, this doesn't mean that Git's normalization process isn't working; it's ju
 
 Fortunately, we can take things a step further with an `.editorconfig` file; this is an [editor-agnostic project](https://editorconfig.org/) that aims to create a standardized format for customizing the behavior of any given text editor. Lots of text editors (including VS Code) support and automatically read this file if it's present. You can put something like this in the root of your workspace:
 
-{% include codeHeader.html file: ".editorconfig" %}
-```
+``` {data-file=".editorconfig" data-copyable=true}
 root = true
 
 [*]

--- a/src/_posts/2021-04-25-format-code-on-save-vs-code-eslint.md
+++ b/src/_posts/2021-04-25-format-code-on-save-vs-code-eslint.md
@@ -33,8 +33,7 @@ Since we want to use ESLint to format JavaScript, we'll need to install the `esl
 
 Run this command to install ESLint with Prettier:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 yarn add -D eslint prettier eslint-plugin-prettier eslint-config-prettier
 ```
 
@@ -45,8 +44,7 @@ If you're linting TypeScript, you'll also want these packages in addition to the
 
 Install them like so:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 yarn add -D @typescript-eslint/eslint-plugin @typescript-eslint/parser
 ```
 
@@ -57,8 +55,7 @@ And if you're linting React, throw these must-haves into the mix:
 
 You get the idea:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 yarn add -D eslint-plugin-react eslint-plugin-react-hooks
 ```
 
@@ -70,8 +67,7 @@ If you already have the ESLint extension installed, VS Code may show a prompt as
 
 If you haven't already done so, you can update your `package.json` scripts to include a script to lint files via the command line. This is useful in case you want to set up lint-staged rules with [husky](https://www.npmjs.com/package/husky) and git hooks:
 
-{% include codeHeader.html file: "package.json" %}
-```json
+```json {data-file="package.json" data-copyable=true}
 {
   "scripts": {
     "lint": "eslint --cache \"src/**/*.{js,jsx,ts,tsx}\"",
@@ -84,15 +80,13 @@ If you haven't already done so, you can update your `package.json` scripts to in
 
 Install `husky` and `lint-staged`:
 
-{% include codeHeader.html %}
-```
+``` {data-copyable=true}
 yarn add -D lint-staged husky
 ```
 
 And configure them in your `package.json` to use the `lint:fix` script you defined:
 
-{% include codeHeader.html file: "package.json" %}
-```json
+```json {data-file="package.json" data-copyable=true}
 {
   "husky": {
     "hooks": {
@@ -146,8 +140,7 @@ Some people use the numerical aliases, but I prefer to use the strings to be exp
 
 Since we're using Prettier to supplement ESLint's formatting rules, we'll need to configure Prettier. You can use this config file for any type of project. Adjust the settings according to your needs:
 
-{% include codeHeader.html file: ".prettierrc" %}
-```json
+```json {data-file=".prettierrc" data-copyable=true}
 {
   "useTabs": false,
   "tabWidth": 2,
@@ -167,8 +160,7 @@ If you're working in a JavaScript or Node environment, you can either rely on th
 
 Note that if you're using the default ESLint parser (i.e., no `parser` set), you can set `ecmaVersion` to `"latest"` [as of ESLint v7.30.0](https://eslint.org/blog/2021/07/eslint-v7.30.0-released#highlights). Otherwise, set it to [one of the accepted values](https://eslint.org/docs/user-guide/configuring/language-options#specifying-environments).
 
-{% include codeHeader.html file: ".eslintrc.json" %}
-```json
+```json {data-file=".eslintrc.json" data-copyable=true}
 {
   "extends": [
     "eslint:recommended",
@@ -214,8 +206,7 @@ With TypeScript, only a few things need to change from the basic ESLint config a
 See the `@typescript-eslint/eslint-plugin` docs for [the full list of rules](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin) and additional instructions on how you can customize this plugin.
 
 
-{% include codeHeader.html file: ".eslintrc.json" %}
-```json
+```json {data-file=".eslintrc.json" data-copyable=true}
 {
   "extends": [
     "eslint:recommended",
@@ -265,8 +256,7 @@ Finally, if you're using ESLint to format React code, you can use either one of 
 
 One important change needs to be made to the `parserOptions` object: We'll need to specify an `ecmaFeatures` object with `"jsx": true` so that ESLint recognizes JSX and formats it correctly, rather than flagging it as an unknown syntax.
 
-{% include codeHeader.html file: ".eslintrc.json" %}
-```json
+```json {data-file=".eslintrc.json" data-copyable=true}
 {
   "extends": [
     "eslint:recommended",
@@ -339,8 +329,7 @@ Click `Allow` (or `Allow everywhere`). If the notification doesn't appear and yo
 
 If you're setting up ESLint in a shared repo, you can also configure the recommended extensions for your project workspace. This will prompt other team members to install the ESLint extension if they don't already have it when they open your workspace in VS Code. To do so, open your command palette and run the command `Configure Recommended Extensions (Workspace Folder)`. This creates an `extensions.json` file in a `.vscode/` folder at the root of your project. Add the string ID for the ESLint extension that you installed:
 
-{% include codeHeader.html file: "extensions.json" %}
-```json
+```json {data-file="extensions.json" data-copyable=true}
 {
   "recommendations": [
     "dbaeumer.vscode-eslint"
@@ -368,8 +357,7 @@ Select either one. I recommend configuring this in both your user and workspace 
 
 Either way, you'll want to add these to your JSON:
 
-{% include codeHeader.html file: ".vscode/settings.json" %}
-```json
+```json {data-file=".vscode/settings.json" data-copyable=true}
 {
   "eslint.validate": [
     "javascript",

--- a/src/_posts/2021-05-31-premature-optimization-code-first-optimize-later.md
+++ b/src/_posts/2021-05-31-premature-optimization-code-first-optimize-later.md
@@ -12,8 +12,7 @@ thumbnail:
 
 Recently, there was a [Twitter thread going around](https://twitter.com/maxfmckay/status/1396252890721918979) that compared two approaches to the same problem in JavaScript: 1) using a single `Array.reduce` call with the ES6 spread operator, and 2) chaining array methods. The two code samples looked something like this (I've renamed the variables to clarify what's going on):
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 // Version 1: reduce with ES6 spread
 users.reduce((offlineUsers, user) => {
   if (user.active) {

--- a/src/_posts/2021-07-03-eleventy-the-good-the-bad-and-the-possum.md
+++ b/src/_posts/2021-07-03-eleventy-the-good-the-bad-and-the-possum.md
@@ -49,8 +49,7 @@ Now that I've gone through this process myself and have experience with various 
 
 As I mentioned earlier, 11ty runs on JavaScript. All of its configs are written in Node, with the base `.eleventy.js` file exporting a function like so:
 
-{% include codeHeader.html file: ".eleventy.js", copyable: false %}
-```js
+```js {data-file=".eleventy.js"}
 module.exports = (eleventyConfg) => {
   // Where the magic happens.
 }
@@ -79,8 +78,7 @@ With 11ty, you have full control over how you want your site to be built.
 
 For example, let's say you want to use SVG icon libraries like [Feather Icons](https://feathericons.com/) on your site. You can install the NPM package, import it into your config, and register a custom shortcode that returns a particular SVG as an inline string:
 
-{% include codeHeader.html file: ".eleventy.js", copyable: false %}
-```js
+```js {data-file=".eleventy.js"}
 const feather = require('feather-icons');
 
 // You'll need to pass more arguments, but this is the general idea
@@ -107,8 +105,7 @@ You can create a shortcode for practically anything, offloading the main renderi
 
 One of the coolest things about 11ty is how easy it is to write **custom template filters**. Tired of repeating {% raw %}`{{ site.url }}`{% endraw %} in your markup? Create a custom filter to prepend your site's URL to any URL string that you give it:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const site = require('./src/_data/site');
 
 const toAbsoluteUrl = (url) => {
@@ -138,8 +135,7 @@ And now you can use it like this anywhere in your code:
 
 Or maybe you have some object data that you want to iterate over in a template. No problem—throw in these filters, and you're good to go:
 
-{% include codeHeader.html file: ".eleventy.js", copyable: false %}
-```js
+```js {data-file=".eleventy.js"}
 module.exports = (eleventyConfig) => {
   eleventyConfig.addLiquidShortcode('keys', Object.keys);
   eleventyConfig.addLiquidShortcode('values', Object.values);
@@ -172,8 +168,7 @@ You can define global site data statically using YAML or JSON, and this works we
 
 For those dynamic use cases, 11ty allows you to define data files using JavaScript. Just stick a JavaScript file in your data directory and export whatever you want from that module; 11ty will handle the rest. For example, you could export an object for static data:
 
-{% include codeHeader.html file: "src/_data/site.js", copyable: false %}
-```js
+```js {data-file="src/_data/site.js"}
 module.exports = {
   title: 'My Awesome Site',
   author: 'My name',
@@ -184,8 +179,7 @@ module.exports = {
 
 But you could also export a function for dynamic data. You can even make it async, allowing you to fetch and await remote data and return it from the data file:
 
-{% include codeHeader.html file: "src/_data/projects.js", copyable: false %}
-```js
+```js {data-file="src/_data/projects.js"}
 module.exports = async () => {
   console.log('Fetching GitHub projects...');
   // fetch and return the data here!
@@ -204,8 +198,7 @@ With Jekyll, pagination was an afterthought, and you had to use [a plugin](https
 
 In 11ty, pagination is built right in—you can paginate All the Things to your heart's content. Eleventy uses the notion of a "tag" to group your content into collections. You can define `tags` in the front matter of any template file or even with [directory-specific data files](https://www.11ty.dev/docs/data-template-dir/). So if you have another collection named `notes` and a source directory like `src/_notes`, you can stick a JSON file in there to automatically tag everything in it as part of the `notes` collection:
 
-{% include codeHeader.html file: "src/_notes/_notes.json" %}
-```json
+```json {data-file="src/_notes/_notes.json" data-copyable=true}
 {
   "tags": ["notes"]
 }
@@ -213,9 +206,8 @@ In 11ty, pagination is built right in—you can paginate All the Things to your 
 
 And then look it up with pagination in your front matter:
 
-{% include codeHeader.html file: "src/notes.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/notes.html" data-copyable=true}
 ---
 title: Notes
 permalink: /notes/
@@ -258,8 +250,7 @@ Pretty cool! But even cooler is that you can **generate collections programmatic
 
 This means that instead of manually tagging your content or using directory data files, you can generate a custom collection with JavaScript and give it any name that you want:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 module.exports = (eleventyConfig) => {
   eleventyConfig.addCollection('posts', (collectionApi) => {
     return collectionApi.getFilteredByGlob('./src/_posts/*.md').reverse();
@@ -277,9 +268,8 @@ In Jekyll and most other static site generators, a front-matter variable can't r
 
 Fortunately, this limitation doesn't exist in 11ty, where you can do magical things thanks to [computed data](https://www.11ty.dev/docs/data-computed/):
 
-{% include codeHeader.html file: "src/_pages/blog.html" %}
 {% raw %}
-```yml
+```yml {data-file="src/_pages/blog.html" data-copyable=true}
 ---
 permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber | plus: 1 }}/{% endif %}"
 pagination:
@@ -306,8 +296,7 @@ What really convinced me to give Eleventy a shot was an article by Ben Holmes ab
 
 Here's some sample code from the official docs showing how you register a custom shortcode for images and generate the required output:
 
-{% include codeHeader.html file: ".eleventy.js", copyable: false %}
-```js
+```js {data-file=".eleventy.js"}
 const Image = require("@11ty/eleventy-img");
 
 async function imageShortcode(src, alt, sizes) {

--- a/src/_posts/2021-07-10-dont-use-a-fixed-line-height.md
+++ b/src/_posts/2021-07-10-dont-use-a-fixed-line-height.md
@@ -133,8 +133,7 @@ Whenever you apply a particular font size to an element, you need to make sure i
 
 You can easily create design tokens for typography using CSS custom properties (or, if you use Sass, a map). Below is one example of what that might look like; you'll likely need to adjust these values to suit your chosen font.
 
-{% include codeHeader.html file: "global.css" %}
-```css
+```css {data-file="global.css" data-copyable=true}
 html {
   --fs-sm: 14px;
   --lh-sm: 24px;
@@ -198,8 +197,7 @@ html {
 
 If you're using a preprocessor like Sass, you can then define a mixin to apply both a font size and its corresponding line height *together*:
 
-{% include codeHeader.html file: "_mixins.scss" %}
-```scss
+```scss {data-file="_mixins.scss" data-copyable=true}
 @mixin font-size($step) {
   font-size: var(--fs-#{$step});
   line-height: var(--lh-#{$step});
@@ -241,8 +239,7 @@ This approach provides a sufficiently accurate approximation of a font's ideal l
 
 Fortunately, if we take the mixin approach that I showed earlier, the fix is rather simple—instead of looking up a particular line height step in our variables, we can just plug in this equation alongside the font size:
 
-{% include codeHeader.html file: "_mixins.scss" %}
-```scss
+```scss {data-file="_mixins.scss" data-copyable=true}
 @mixin font-size($step) {
   font-size: var(--fs-#{$step});
   line-height: calc(4px + 2ex);

--- a/src/_posts/2021-08-01-javascript-promise-all.md
+++ b/src/_posts/2021-08-01-javascript-promise-all.md
@@ -64,8 +64,7 @@ Let's tackle the problem that I described in this article's intro, where a user 
 
 To keep this article simple, I won't use any real-world data. Instead, I'll simulate the problem with a helper function that returns a promise and resolves it after `n` seconds:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const wait = (delaySeconds) => {
   return new Promise((resolve) => {
     setTimeout(() => resolve(), delaySeconds * 1000);
@@ -89,8 +88,7 @@ const someAsyncFn = async () => {
 
 We can use this function to simulate an async task that takes some time to complete, like an upload. We'll use an array of numbers to represent the time it takes each file to upload:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const uploadFile = async (delay, index) => {
   await wait(delay);
   console.log(`uploaded file ${index + 1}`);
@@ -122,8 +120,7 @@ That's it for simulating the problem in code.
 
 Now, let's use `Promise.all` to log a message once *all* of the promises have resolved:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 const uploadFiles = async (files) => {
   try {
     const fileUploads = files.map((delay, i) => uploadFile(delay, i));
@@ -180,8 +177,7 @@ Finally, note that there's no straightforward way to get the size of an iterable
 
 Here's the code:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 Promise.all = (promises) => {
   const resolvedValues = [];
   let promiseCount = 0;
@@ -220,8 +216,7 @@ Each time a promise resolves, we push the resolved value to an array and check i
 
 There's one edge case that our code doesn't handle: an empty iterable. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all#return_value), the expected behavior is that `Promise.all` should resolve immediately. Fortunately, the fix is simple in our case since we already computed the size of the input:
 
-{% include codeHeader.html %}
-```javascript
+```javascript {data-copyable=true}
 Promise.all = (promises) => {
   const resolvedValues = [];
   let promiseCount = 0;

--- a/src/_posts/2021-08-08-eleventy-netlify-redirects.md
+++ b/src/_posts/2021-08-08-eleventy-netlify-redirects.md
@@ -26,8 +26,7 @@ After your site gets built, Netlify's redirects engine processes and registers t
 
 You can create this file and list all of your redirects by hand. Then, all you need to do is tell 11ty to pass-through copy this file to your output directory so that Netlify sees it:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 module.exports = (eleventyConfig) => {
   // Assuming your file resides under src/_redirects
   eleventyConfig.addPassthroughCopy('src/_redirects');
@@ -44,9 +43,8 @@ Create a file named `redirects.liquid` in your Eleventy source folder. I'm using
 
 Declare this front matter to start things off:
 
-{% include codeHeader.html file: "src/redirects.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/redirects.liquid" data-copyable=true}
 ---
 permalink: /_redirects
 eleventyExcludeFromCollections: true
@@ -72,9 +70,8 @@ But the whole point of using a template file is so that we can take advantage of
 
 Instead, what if we introduce a custom front-matter variable, like `redirectFrom`, that a page can use to specify the URL from which it redirects? We can then loop through all pages like this and generate our Netlify redirect rules:
 
-{% include codeHeader.html file: "src/redirects.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/redirects.liquid" data-copyable=true}
 ---
 permalink: /_redirects
 eleventyExcludeFromCollections: true
@@ -95,9 +92,8 @@ We check to see if a page has a valid URL and if its front matter specifies a `r
 
 Now, whenever you want to change a page's URL structure, all you need to do is track the old URL in its front matter and update the file name/permalink/slug to be the new URL:
 
-{% include codeHeader.html file: "_posts/2021-08-07-new-url.md", copyable: false %}
 {% raw %}
-```liquid
+```liquid {data-file="_posts/2021-08-07-new-url.md"}
 ---
 redirectFrom: /blog/old-url/
 ---
@@ -106,8 +102,7 @@ redirectFrom: /blog/old-url/
 
 For this particular example, assuming that your blog post permalinks are derived from the file slug, 11ty would output the following Netlify `_redirects` file:
 
-{% include codeHeader.html file: "_redirects", copyable: false %}
-```
+``` {data-file="_redirects"}
 /blog/old-url/  /blog/new-url/
 ```
 
@@ -117,9 +112,8 @@ Above, we assumed that `redirectFrom` is a single string. But if a URL changes s
 
 To handle this case, we can make `redirectFrom` an array:
 
-{% include codeHeader.html file: "_posts/2021-08-07-new-url.md", copyable: false %}
 {% raw %}
-```liquid
+```liquid {data-file="_posts/2021-08-07-new-url.md"}
 ---
 redirectFrom: [url1, url2]
 ---
@@ -128,9 +122,8 @@ redirectFrom: [url1, url2]
 
 This would just require an additional loop to iterate over each URL for a given page:
 
-{% include codeHeader.html file: "src/redirects.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/redirects.liquid" data-copyable=true}
 ---
 permalink: /_redirects
 eleventyExcludeFromCollections: true

--- a/src/_posts/2021-08-24-react-lazy-dynamic-imports.md
+++ b/src/_posts/2021-08-24-react-lazy-dynamic-imports.md
@@ -53,8 +53,7 @@ For this tutorial, I've prepared a [CodeSandbox demo of dynamic imports in React
 
 Let's suppose we have a simple React app that renders tab panels and some buttons to change the current tab. Each tab panel is its own component; the ones in this demo are very simple and just display some mock text, but in a real app, a tab panel might contain paragraphs of text, imagery, videos, and more (depending on what the tabs are being used for). We'll first import each tab panel statically, like so:
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 import Tab1 from './components/Tab1';
 import Tab2 from './components/Tab2';
 import Tab3 from './components/Tab3';
@@ -63,8 +62,7 @@ import Tab4 from './components/Tab4';
 
 Let's also create a static array for our tabs. Each entry contains an object config with two properties: the component to render for the tab panel, and whether the tab is disabled (optional).
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 const tabs = [
   { component: Tab1 },
   { component: Tab2 },
@@ -75,8 +73,7 @@ const tabs = [
 
 Finally, we'll render the tabs and maintain some state to toggle the active tab:
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 const App = () => {
   const [currentTabIndex, setCurrentTabIndex] = useState(0);
 
@@ -127,8 +124,7 @@ Unlike static imports, React's dynamic imports don't bundle the module at compil
 
 There's just one catch: We need to specify some fallback UI for the dynamically imported component. That way, between the time when we request the component and the time when the dynamic import resolves, the React tree isn't left in a limbo state where it has no valid UI for a node. We can do this using React's specially made `Suspense` component, which takes a `fallback` prop and wraps the lazy component:
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 import { lazy, Suspense } from 'react';
 
 const MyComponent = lazy(() => import('path/to/component'));
@@ -146,8 +142,7 @@ You can also specify a fallback of `null` if you don't need a placeholder; this 
 
 And that's all there is to it! Let's refactor our imports from earlier. Instead of doing this:
 
-{% include codeHeader.html file: "App.jsx", copyable: false %}
-```jsx
+```jsx {data-file="App.jsx"}
 import Tab1 from './components/Tab1';
 import Tab2 from './components/Tab2';
 import Tab3 from './components/Tab3';
@@ -156,8 +151,7 @@ import Tab4 from './components/Tab4';
 
 We'll do this:
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 import { lazy, Suspense } from 'react';
 const Tab1 = lazy(() => import('./components/Tab1'));
 const Tab2 = lazy(() => import('./components/Tab2'));
@@ -167,8 +161,7 @@ const Tab4 = lazy(() => import('./components/Tab4'));
 
 And then we'll update our render function here to use `Suspense`:
 
-{% include codeHeader.html file: "App.jsx" %}
-```jsx
+```jsx {data-file="App.jsx" data-copyable=true}
 const renderTabPanel = () => {
   const TabPanel = tabs[currentTabId].component;
   return (

--- a/src/_posts/2021-09-03-passing-object-arguments-to-liquid-shortcodes-in-11ty.md
+++ b/src/_posts/2021-09-03-passing-object-arguments-to-liquid-shortcodes-in-11ty.md
@@ -18,9 +18,8 @@ Whenever you only want to pass along just one optional argument but not any of t
 
 As a temporary workaround, we can create a wrapper include that forwards named arguments to the shortcode. But this is still not ideal because you need to pass the arguments in a specific order to the shortcode, and that can easily break if your shortcode's signature is updated:
 
-{% include codeHeader.html file: "src/_includes/myShortcode.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/myShortcode.html" data-copyable=true}
 {%- comment -%}This works, so long as the order doesn't change.{%- endcomment -%}
 {% myShortcode arg1, arg2, arg3, arg4 %}
 ```
@@ -62,9 +61,8 @@ We'll then pass that object to the shortcode as an argument.
 
 We'll start by formatting a JSON string and interpolating the named arguments of the include:
 
-{% include codeHeader.html file: "src/_includes/myShortcode.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/myShortcode.html" data-copyable=true}
 {%- capture props -%}
   {
     "arg1": "{{ arg1 }}",
@@ -117,15 +115,13 @@ I prefer the second approach because it means that I can later programmatically 
 
 Let's add this filter to our Eleventy config to enable parsing JSON strings:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 eleventyConfig.addFilter('fromJson', JSON.parse);
 ```
 And let's use it to transform the `props` string into a JavaScript object:
 
-{% include codeHeader.html file: "src/_includes/myShortcode.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/myShortcode.html" data-copyable=true}
 {%- capture props -%}
   {
     "arg1": "{{ arg1 }}",
@@ -145,9 +141,8 @@ Now, our shortcode receives an object argument with all of our interpolated valu
 
 Let's look at that JSON again:
 
-{% include codeHeader.html file: "src/_includes/myShortcode.html" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/myShortcode.html" data-copyable=true}
 {%- capture props -%}
   {
     "arg1": "{{ arg1 }}",

--- a/src/_posts/2021-10-10-managing-complex-state-react-usereducer.md
+++ b/src/_posts/2021-10-10-managing-complex-state-react-usereducer.md
@@ -31,8 +31,7 @@ In this tutorial, we'll explore a simplified version of the scenario I described
 
 Let's first look at a naive approach, where we use multiple `useState` calls to manage state:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 type Mode = 'idle' | 'loading' | 'no-results' | 'error';
 
 const ImageSearch = () => {
@@ -46,8 +45,7 @@ const ImageSearch = () => {
 
 We'll use the following `useEffect` hook to fetch images from the API whenever the user enters a new search query or requests the next page of images:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 useEffect(() => {
   const fetchImages = async () => {
     try {
@@ -76,8 +74,7 @@ Notice that whenever we're setting the image results, we're also setting the app
 
 Finally, we can define some event handlers and render our UI:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 const handleQueryChange = debounce((e: ChangeEvent<HTMLInputElement>) => {
   setQuery(e.target.value);
   setImages([]);
@@ -232,8 +229,7 @@ That's all you really need to know about `useReducer`. Let's use what we know to
 
 If you're using TypeScript, you should start by documenting your component's state with a type/interface. At this point, you can also add jsDoc comments to each of the state properties to clarify their usage whenever a developer hovers over them or tries to access them in their editor.
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 type State = {
   /** A high-level description of the current state of the app
    * (e.g., if it's loading or encountered an error). */
@@ -251,8 +247,7 @@ type State = {
 
 From this type, we can derive an initial state:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 const initialState: State = {
   mode: 'idle',
   images: [],
@@ -266,8 +261,7 @@ In the original code sample, our component's state was initialized with multiple
 
 Now, we need to define a reducer. Recall that a reducer is a function that takes two arguments: the current state (of type `State`) and an action to dispatch. If you're using TypeScript, you'll want to create a type union to list all of the allowed actions. I'll follow the `type/payload` convention:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 type Action = |
  | { type: 'set-mode'; payload: Mode }
  | { type: 'set-images'; payload: { images: ImageResult[]; totalPages: number; } }
@@ -283,8 +277,7 @@ Observe two things about these action types:
 
 Now that we've defined the types for our state and actions, we can create the reducer. I'll use a switch statement to cycle through all of the possible action types. In the default case statement, when the reducer is initializing the component's state for the first time, we'll return the initial state that we defined earlier.
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'set-mode': {
@@ -312,8 +305,7 @@ This doesn't really do anything meaningful just yet. Right now, the reducer will
 
 Finally, we can use the `useReducer` hook to initialize our function component's state:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 const ImageSearch = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   // ...
@@ -362,8 +354,7 @@ Alright, let's fill in these case statements one by one.
 
 Here's `'set-mode'`:
 
-{% include codeHeader.html  file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx"}
 case 'set-mode': {
   return { ...state, mode: action.payload };
 }
@@ -379,9 +370,7 @@ Then `state.mode` will be `'loading'`.
 
 Next up is `'set-images'`, which has a bit more logic than just updating a single state property. In our example, this action gets dispatched once we receive an API response:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-
-```tsx
+```tsx {data-file="ImageSearch.tsx"}
 case 'set-images': {
   const { images, totalPages } = action.payload;
   const newImages = [...state.images, ...images];
@@ -394,8 +383,7 @@ The great thing about the reducer pattern is that it allows us to bundle all of 
 
 Next up is `'set-query'`, for when a user enters a search term in the input box:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-```tsx
+```tsx {data-file="ImageSearch.tsx" data-copyable=true}
 case 'set-query': {
   return { ...initialState, query: action.payload };
 }
@@ -405,9 +393,7 @@ This time around, we spread in the initial state rather than the current state. 
 
 Here's `'fetch-next-page'`, for when a user clicks the load-more button:
 
-{% include codeHeader.html file: "ImageSearch.tsx" %}
-
-```tsx
+```tsx {data-file="ImageSearch.tsx"}
 case 'fetch-next-page': {
   const nextPage = state.queryPage + 1;
   if (nextPage >= state.totalPages) return state;
@@ -448,8 +434,7 @@ useEffect(() => {
 
 Here's what it looks like if we refactor it to use the dispatcher returned by `useReducer`:
 
-{% include codeHeader.html %}
-```tsx
+```tsx {data-copyable=true}
 useEffect(() => {
   const fetchImages = async () => {
     try {
@@ -489,8 +474,7 @@ const loadMoreImages = () => {
 
 We can now rewrite them using our dispatch function:
 
-{% include codeHeader.html %}
-```tsx
+```tsx {data-copyable=true}
 const handleQueryChange = debounce((e: ChangeEvent<HTMLInputElement>) => {
   dispatch({ type: 'set-query', payload: e.target.value });
 }, 300);

--- a/src/_posts/2021-10-31-eleventy-image-lazy-loading.md
+++ b/src/_posts/2021-10-31-eleventy-image-lazy-loading.md
@@ -35,15 +35,13 @@ Before we dive deep into the code specific to this tutorial, I want us to take s
 
 To get started, install the 11ty image plugin:
 
-{% include codeHeader.html %}
-```bash
+```bash {data-copyable=true}
 yarn add -D @11ty/eleventy-img
 ```
 
 And import it into any Node script:
 
-{% include codeHeader.html %}
-```js
+```js {data-copyable=true}
 const Image = require('@11ty/eleventy-img');
 ```
 
@@ -181,8 +179,7 @@ Not all 11ty projects are structured in the same way. Some developers prefer to 
 
 Our first step is to create an image shortcode and register it in the 11ty config:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const Image = require('@11ty/eleventy-img');
 
 const imageShortcode = async (relativeSrc, alt, className, widths, formats, sizes) => {
@@ -204,8 +201,7 @@ module.exports = (eleventyConfig) => {
 
 Let's start writing some of the logic for our image shortcode. We'll define fallbacks for some of the optional arguments, read the absolute path to the image on the file system, and pass along all of the relevant options to the image plugin. Note that I won't be covering remote images in this tutorial, so you may need to write some of your own logic to handle those (it should be fairly straightforward).
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const Image = require('@11ty/eleventy-img');
 const path = require('path');
 
@@ -411,8 +407,7 @@ Let's tackle the steps outlined above.
 
 Since 11ty allows us to specify widths for our images, we can also include a tiny placeholder width. You can use any width you like for this. Smaller widths will produce more pixelated and distorted placeholders, but they'll also use less space. I'll use `24` in this tutorial.
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const ImageWidths = {
   ORIGINAL: null,
   PLACEHOLDER: 24,
@@ -465,8 +460,7 @@ However, we want to lazily load images by hand. The reason I recommend doing thi
 
 So, instead of using `Image.generateHTML`, we can assemble a custom HTML string:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const imageShortcode = async (
   relativeSrc,
   alt,
@@ -518,8 +512,7 @@ const imageShortcode = async (
 
 Now, we'll assemble the `formats` array from these two arguments:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 const imageShortcode = async (
   relativeSrc,
   alt,
@@ -544,8 +537,7 @@ const imageShortcode = async (
 
 We'll need one more bit of information before we can define our markup: the placeholder image and largest image corresponding to each format (WebP, JPEG, and whatever other formats you've defined). Here's a `reduce` over the metadata object that'll do that for us:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 // Map each unique format (e.g., jpeg, webp) to its smallest and largest images
 const formatSizes = Object.entries(imageMetadata).reduce((formatSizes, [format, images]) => {
   if (!formatSizes[format]) {
@@ -566,8 +558,7 @@ In our case, this returns an object whose keys are `jpeg` and `webp`; for each k
 
 We now have everything that we need to define our image markup:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 // Chain class names w/ the classNames package; optional
 const picture = `<picture class="${classNames('lazy-picture', className)}">
 ${Object.values(imageMetadata)
@@ -648,8 +639,7 @@ As a reminder, we're storing all of the real image sources and srcsets in `data-
 
 We'll start by creating a utility function that takes two arguments: an iterable containing all of the DOM nodes that we want to watch for intersections with the viewport, and the callback to fire when those elements intersect with the viewport. Under the hood, this utility will use the [`IntersectionObserver` API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API):
 
-{% include codeHeader.html %}
-```js
+```js {data-copyable=true}
 const lazyLoad = (targets, onIntersection) => {
   const observer = new IntersectionObserver((entries, self) => {
     entries.forEach((entry) => {
@@ -665,8 +655,7 @@ const lazyLoad = (targets, onIntersection) => {
 
 We can then use it like so:
 
-{% include codeHeader.html file: "src/assets/scripts/index.mjs" %}
-```js
+```js {data-file="src/assets/scripts/index.mjs" data-copyable=true}
 const lazyPictures = document.querySelectorAll('.lazy-picture');
 lazyLoad(lazyPictures, (pictureElement) => {
   const img = pictureElement.querySelector('img');
@@ -707,8 +696,7 @@ This is all of the core logic that you need for the custom lazy loading solution
 
 If you want your images to fade in more smoothly, you can use the CSS `blur` filter:
 
-{% include codeHeader.html file: "image.css" %}
-```css
+```css {data-file="image.css" data-copyable=true}
 .lazy-img {
   filter: blur(8px);
   transition: filter 0.3s ease-in;

--- a/src/_posts/2021-11-14-configuring-web-fonts-in-11ty-with-global-data.md
+++ b/src/_posts/2021-11-14-configuring-web-fonts-in-11ty-with-global-data.md
@@ -55,8 +55,7 @@ Instead, I wanted to have a single source of truth for our fonts that I could ex
 
 To get started, create a file named `fonts.js` in your data directory. I'll define some object enums upfront to avoid typos:
 
-{% include codeHeader.html file: "src/_data/fonts.js" %}
-```js
+```js {data-file="src/_data/fonts.js" data-copyable=true}
 const FontStyle = {
   NORMAL: 'normal',
   ITALIC: 'italic',
@@ -77,8 +76,7 @@ const FontVariant = {
 
 We can also define a utility for generating font URLs:
 
-{% include codeHeader.html file: "src/_data/fonts.js" %}
-```js
+```js {data-file="src/_data/fonts.js" data-copyable=true}
 const path = require('path');
 
 /** Helper to auto-prefix a font src url with the path to local fonts. */
@@ -87,8 +85,7 @@ const getFontUrl = (src) => path.join('/assets/fonts', src);
 
 Finally, we can export an object describing our fonts. For each font, we'll specify the family name, an array of fallbacks, and the font weights. I'm using the fonts from my site for illustrative purposes; feel free to replace them with whatever fonts you want:
 
-{% include codeHeader.html file: "src/_data/fonts.js" %}
-```js
+```js {data-file="src/_data/fonts.js" data-copyable=true}
 const fonts = {
   body: {
     family: 'Fira Sans',
@@ -177,16 +174,14 @@ With our global font config in place, we can begin generating `@font-face` decla
 
 To iterate over the fonts, we'll need a custom filter that allows us to loop over object values. This will do the trick:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 eleventyConfig.addFilter('values', Object.values);
 ```
 
 With that out of the way, we can now loop over the font config's values:
 
-{% include codeHeader.html file: "src/_includes/fontFace.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/fontFace.liquid" data-copyable=true}
 {%- assign allFonts = fonts | values -%}
 {%- for font in allFonts -%}
   {%- assign weights = font.weights | values -%}
@@ -275,9 +270,8 @@ Given our font config, this will produce the following `@font-face` declarations
 
 We can now head over to our base layout and inline the CSS string we just created:
 
-{% include codeHeader.html file: "src/_layouts/default.html" %}
 {% raw %}
-```html
+```html {data-file="src/_layouts/default.html" data-copyable=true}
 <head>
   {%- capture fontCss -%}
     {%- include fontFace.liquid -%}
@@ -307,9 +301,8 @@ eleventyConfig.addFilter('compileAndMinifyCss', compileAndMinifyCss);
 
 If you're not using Sass, you could install any other package that can be used to minify CSS, like [clean-css](https://www.npmjs.com/package/clean-css). Either way, you'll want to use your newly created filter to transform the font CSS string:
 
-{% include codeHeader.html file: "src/_layouts/default.html" %}
 {% raw %}
-```html
+```html {data-file="src/_layouts/default.html" data-copyable=true}
 <head>
   {%- capture fontCss -%}
     {%- include fontFace.liquid -%}
@@ -323,16 +316,14 @@ If you're not using Sass, you could install any other package that can be used t
 
 Now comes the fun part: Using our same font config, we can create yet another include that loops over all of the fonts and generates CSS custom properties for the font families and weights. Before doing that, just like before, we'll want to add one more filter to help us out:
 
-{% include codeHeader.html file: ".eleventy.js" %}
-```js
+```js {data-file=".eleventy.js" data-copyable=true}
 eleventyConfig.addFilter('entries', Object.entries);
 ```
 
 We'll use it like so to get the font config entries:
 
-{% include codeHeader.html file: "src/_includes/fontVariables.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/fontVariables.liquid" data-copyable=true}
 {%- assign allFonts = fonts | entries -%}
 ```
 {% endraw %}
@@ -354,9 +345,8 @@ For the example fonts used in this tutorial, that will produce this array:
 
 Now, we'll loop over all of the entries and generate custom properties for the font families and weights:
 
-{% include codeHeader.html file: "src/_includes/fontVariables.liquid" %}
 {% raw %}
-```liquid
+```liquid {data-file="src/_includes/fontVariables.liquid" data-copyable=true}
 html {
   {%- for font in allFonts -%}
     {%- assign fontType = font | first -%}
@@ -398,9 +388,8 @@ From this point onward, we'll never need to update our CSS again whenever we cha
 
 If you're using Sass, I also recommend setting up a mixin to make your life a little easier:
 
-{% include codeHeader.html file: "mixins.scss" %}
 {% raw %}
-```scss
+```scss {data-file="mixins.scss" data-copyable=true}
 @mixin font($family, $weight) {
   font-family: var(--font-family-#{$family});
   font-weight: var(--font-weight-#{$family}-#{$weight});
@@ -422,9 +411,8 @@ This does require keeping your mixin in sync with your chosen naming format for 
 
 Just like before, we'll want to go back to our base layout and add the new include as part of the overall CSS string that gets compiled and minified in the head:
 
-{% include codeHeader.html file: "src/_layouts/default.html" %}
 {% raw %}
-```html
+```html {data-file="src/_layouts/default.html" data-copyable=true}
 <head>
   {%- capture fontCss -%}
     {%- include fontFace.liquid -%}

--- a/src/_posts/2021-12-03-load-more-button-focus.md
+++ b/src/_posts/2021-12-03-load-more-button-focus.md
@@ -36,8 +36,7 @@ I'll use React for the code samples, but again, you could extend this to any fra
 
 Suppose we're rendering a simple grid of results like this:
 
-{% include codeHeader.html file: "ResultGrid.jsx", copyable: false %}
-```jsx
+```jsx {data-file="ResultGrid.jsx"}
 const ResultGrid = (props) => {
   return (
     <>
@@ -58,8 +57,7 @@ const ResultGrid = (props) => {
 
 As I mentioned, we'll need to maintain a reference to the last rendered result. Fortunately, this is straightforward in React because we're using a mapping function to render the list items, so we can easily determine if we're looking at the last one by checking its index. We can then assign a ref to keep track of the last element:
 
-{% include codeHeader.html file: "ResultGrid.jsx" %}
-```jsx
+```jsx {data-file="ResultGrid.jsx" data-copyable=true}
 const ResultGrid = (props) => {
   const lastResultRef = useRef(null);
 

--- a/src/_posts/2021-12-27-fluid-type-scale-with-css-clamp.md
+++ b/src/_posts/2021-12-27-fluid-type-scale-with-css-clamp.md
@@ -244,8 +244,7 @@ p {
 
 To set defaults for the min and max breakpoints, we'll start by creating a map for our media breakpoints and importing some Sass namespaces (only needed if you're using Dart Sass):
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 @use "sass:math";
 @use "sass:map";
 
@@ -258,8 +257,7 @@ $media-breakpoints: (
 
 Next, we'll create our Sass function and set the default min and max breakpoints to mobile and desktop, respectively. That way, we can pass in overrides on a case-by-case basis but fall back to the logic of "min equals mobile" and "max equals desktop."
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 $default-min-bp: map.get($media-breakpoints, "mobile");
 $default-max-bp: map.get($media-breakpoints, "desktop");
 
@@ -270,8 +268,7 @@ $default-max-bp: map.get($media-breakpoints, "desktop");
 
 Now, we just need to find the slope and intercept of the equation representing the preferred value for clamp—the line between the min and max points. Here's the code for that bit:
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 $slope: math.div($max-px - $min-px, $max-bp - $min-bp);
 $intercept-px: $min-px - $slope * $min-bp;
 $slope-vw: $slope * 100;
@@ -285,8 +282,7 @@ And that's all the information that we need! The final step is to return a vanil
 
 However, as I mentioned before, we don't want to use pixels for font sizing. To fix this, we can create another Sass function that can convert pixels to rems (maybe you already have one in your code base):
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 @function to-rems($px) {
   $rems: math.div($px, 16px) * 1rem;
   @return $rems;
@@ -295,8 +291,7 @@ However, as I mentioned before, we don't want to use pixels for font sizing. To 
 
 And we'll use it to convert all of our pixels to rems. Here's the final code:
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 @function clamped($min-px, $max-px, $min-bp: $default-min-bp, $max-bp: $default-max-bp) {
   $slope: math.div($max-px - $min-px, $max-bp - $min-bp);
   $slope-vw: $slope * 100;
@@ -309,8 +304,7 @@ And we'll use it to convert all of our pixels to rems. Here's the final code:
 
 Finally, note that depending on what values you pass into this function, you may get really long floating-point numbers. You can truncate them using a custom rounding function:
 
-{% include codeHeader.html file: "_functions.scss" %}
-```scss
+```scss {data-file="_functions.scss" data-copyable=true}
 @function rnd($number, $places: 0) {
   $n: 1;
   @if $places > 0 {
@@ -465,8 +459,7 @@ The good news is that the work is essentially cut out for us, especially if we m
 
 We'll start by creating the following variables:
 
-{% include codeHeader.html file: "_variables.scss" %}
-```scss
+```scss {data-file="_variables.scss" data-copyable=true}
 @use "sass:math";
 
 $type-base: 16px;
@@ -479,8 +472,7 @@ The `$type-steps` list contains the names of all of the steps in our type scale.
 
 Now, we'll loop over the modular steps and combine everything we've learned so far to programmatically generate font variables:
 
-{% include codeHeader.html file: "index.scss" %}
-```scss
+```scss {data-file="index.scss" data-copyable=true}
 html {
   @for $i from 1 through length($type-steps) {
     $step: list.nth($type-steps, $i);
@@ -562,24 +554,21 @@ The approach we just explored involves picking a minimum font size for the base 
 
 Instead, you may want the min and max font sizes to be independent. In that case, rather than specifying just a min font size and a single type scale, we actually need to have two separate sets of variables: one for the minimum (mobile) and another for the maximum (desktop). So whereas before we had just one base font size, now we'll need two: an explicit minimum and maximum font size.
 
-{% include codeHeader.html file: "_variables.scss" %}
-```scss
+```scss {data-file="_variables.scss" data-copyable=true}
 $type-base-min: 16px;
 $type-base-max: 19px;
 ```
 
 Similarly, we'll need a corresponding minimum and maximum type scale:
 
-{% include codeHeader.html file: "_variables.scss" %}
-```scss
+```scss {data-file="_variables.scss" data-copyable=true}
 $type-scale-min: 1.2;
 $type-scale-max: 1.333;
 ```
 
 And now, we'll adjust our loop to use these new variables for the min and max, respectively:
 
-{% include codeHeader.html file: "index.scss" %}
-```scss
+```scss {data-file="index.scss" data-copyable=true}
 html {
   @for $i from 1 through length($type-steps) {
     $step: list.nth($type-steps, $i);

--- a/src/assets/scripts/index.mjs
+++ b/src/assets/scripts/index.mjs
@@ -12,11 +12,15 @@ const themeToggle = new ThemeToggle({
   },
 });
 
-const copyableCodeBlocks = document.querySelectorAll('.code-header.with-copy-button + pre[class*="language-"]');
-const copyCodeButtons = document.querySelectorAll('.copy-code-button');
+const copyableCodeBlocks = document.querySelectorAll('code[data-copyable="true"]');
+copyableCodeBlocks.forEach((codeBlock) => {
+  const code = codeBlock.innerText;
 
-copyCodeButtons.forEach((copyCodeButton, index) => {
-  const code = copyableCodeBlocks[index].innerText;
+  const copyCodeButton = document.createElement('button');
+  copyCodeButton.className = 'copy-code-button font-sm';
+  copyCodeButton.setAttribute('aria-label', 'Copy code to clipboard');
+  copyCodeButton.type = 'button';
+  codeBlock.prepend(copyCodeButton);
 
   copyCodeButton.addEventListener('click', () => {
     window.navigator.clipboard.writeText(code);

--- a/src/assets/scripts/index.mjs
+++ b/src/assets/scripts/index.mjs
@@ -20,7 +20,7 @@ copyableCodeBlocks.forEach((codeBlock) => {
   copyCodeButton.className = 'copy-code-button font-sm';
   copyCodeButton.setAttribute('aria-label', 'Copy code to clipboard');
   copyCodeButton.type = 'button';
-  codeBlock.prepend(copyCodeButton);
+  codeBlock.append(copyCodeButton);
 
   copyCodeButton.addEventListener('click', () => {
     window.navigator.clipboard.writeText(code);

--- a/src/assets/styles/partials/_functions.scss
+++ b/src/assets/styles/partials/_functions.scss
@@ -40,6 +40,7 @@
 
 $default-min-bp: map.get($media-breakpoints, "mobile");
 $default-max-bp: map.get($media-breakpoints, "desktop");
+
 /// Returns a CSS clamp(...) declaration, with the responsive argument computed automatically.
 @function clamped($min-px, $max-px, $min-bp: $default-min-bp, $max-bp: $default-max-bp) {
   $slope: math.div($max-px - $min-px, $max-bp - $min-bp);

--- a/src/assets/styles/partials/components/_codeBlock.scss
+++ b/src/assets/styles/partials/components/_codeBlock.scss
@@ -2,10 +2,12 @@
 
 /* VS Code Dark Plus theme: https://github.com/PrismJS/prism-themes/blob/master/themes/prism-vsc-dark-plus.css */
 
+$code-block-padding: 3.2rem;
+
 pre[class*="language-"] {
   background: var(--color-code-background);
   box-shadow: var(--code-block-box-shadow);
-  padding: 3.2rem;
+  padding: $code-block-padding;
   border-radius: 0.8rem;
   color: var(--color-code-text);
   text-align: start;
@@ -128,7 +130,7 @@ pre[data-line] {
   left: 0;
   color: var(--color-code-text);
   word-break: break-all;
-  padding: 2.4rem 2.4rem 0;
+  padding: $code-block-padding $code-block-padding 0;
   border-radius: 0.8rem 0.8rem 0 0;
   background-color: var(--color-code-background);
   @include font($family: "title", $weight: "bold", $size: "sm");
@@ -140,8 +142,8 @@ pre[data-line] {
 
 .copy-code-button {
   position: absolute;
-  right: 2.4rem;
-  top: 2.4rem;
+  right: $code-block-padding;
+  top: $code-block-padding;
   display: none;
   color: var(--color-code-text);
   background-color: var(--color-code-overlay-1);

--- a/src/assets/styles/partials/components/_codeBlock.scss
+++ b/src/assets/styles/partials/components/_codeBlock.scss
@@ -1,8 +1,9 @@
+@import "../functions";
 @import "../mixins";
 
 /* VS Code Dark Plus theme: https://github.com/PrismJS/prism-themes/blob/master/themes/prism-vsc-dark-plus.css */
 
-$code-block-padding: 3.2rem;
+$code-block-padding: clamped(16px, 32px);
 
 pre[class*="language-"] {
   background: var(--color-code-background);
@@ -120,7 +121,7 @@ pre[data-line] {
 
   // Code blocks with a file name need a bit of top padding
   &.with-file-name + pre[class*="language-"] {
-    padding-top: 7.6rem;
+    padding-top: clamped(48px, 76px);
   }
 }
 

--- a/src/assets/styles/partials/components/_codeBlock.scss
+++ b/src/assets/styles/partials/components/_codeBlock.scss
@@ -8,15 +8,40 @@ $code-block-padding: clamped(16px, 32px);
 pre[class*="language-"] {
   background: var(--color-code-background);
   box-shadow: var(--code-block-box-shadow);
-  padding: $code-block-padding;
   border-radius: 0.8rem;
   color: var(--color-code-text);
-  text-align: start;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  tab-size: 2;
-  overflow-x: auto;
+  margin-inline: calc(-1 * var(--padding));
+  @include tablet {
+    margin-inline: 0;
+  }
+
+  code {
+    padding: $code-block-padding;
+    position: relative;
+    text-align: start;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    tab-size: 2;
+    overflow-x: auto;
+    display: block;
+
+    &[data-file] {
+      padding-top: clamped(48px, 76px);
+
+      // File name
+      &::before {
+        content: "Filename: " attr(data-file);
+        position: absolute;
+        top: 0;
+        left: 0;
+        color: var(--color-code-text);
+        word-break: break-all;
+        padding: $code-block-padding $code-block-padding 0;
+        @include font($family: "title", $weight: "bold", $size: "sm");
+      }
+    }
+  }
 
   .namespace {
     opacity: 0.7;
@@ -100,44 +125,6 @@ pre[class*="language-sass"] {
 pre[class*="language-bash"] {
   .token:not(.comment) {
     color: var(--color-code-text) !important;
-  }
-}
-
-/* Line highlighting */
-
-pre[data-line] {
-  position: relative;
-}
-
-.highlight-line,
-.highlight-line-active {
-  background: var(--color-code-selection);
-}
-
-.code-header {
-  height: 0;
-  z-index: 2;
-  position: relative;
-
-  // Code blocks with a file name need a bit of top padding
-  &.with-file-name + pre[class*="language-"] {
-    padding-top: clamped(48px, 76px);
-  }
-}
-
-.code-file-name {
-  position: absolute;
-  top: 0;
-  left: 0;
-  color: var(--color-code-text);
-  word-break: break-all;
-  padding: $code-block-padding $code-block-padding 0;
-  border-radius: 0.8rem 0.8rem 0 0;
-  background-color: var(--color-code-background);
-  @include font($family: "title", $weight: "bold", $size: "sm");
-
-  &::before {
-    content: "Filename: ";
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8680,6 +8680,11 @@ markdown-it-anchor@^8.0.3:
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.0.4.tgz#58b8dec4e98c476c59255885aaddae3b9849b0b1"
   integrity sha512-/WzolvDEyPiLfmvyWirPerHZX41o4ObHhsz4DrYqTvafXie1ItqWlEajiq77qFAibowAXL9UExb1yeICLUT0+w==
 
+markdown-it-attrs@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-4.1.3.tgz#2b5ab8371ae947155566eaabe8c73548e816dfcd"
+  integrity sha512-d5yg/lzQV2KFI/4LPsZQB3uxQrf0/l2/RnMPCPm4lYLOZUSmFlpPccyojnzaHkfQpAD8wBHfnfUW0aMhpKOS2g==
+
 markdown-it-link-attributes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-link-attributes/-/markdown-it-link-attributes-3.0.0.tgz#12d6f403102ac22695ee2617bec109ee79426e45"


### PR DESCRIPTION
- Code blocks have clamped padding.
- Code blocks are full-bleed on mobile.
- Code blocks now get `data-copyable=true` if they can be copied and `data-file=the_file_name` if they have a file name.
- File names are rendered with CSS `content: attr(data-file)`.
- Copy-to-clipboard buttons are injected with JS. This has a few benefits: 1) smaller initial HTML, 2) if JS is disabled, the buttons won't render, 3) less strain on 11ty since I'm no longer using an include.

All replacements performed w/ VS Code's find & replace regex.